### PR TITLE
Flags that are parsed using argparse are aware of subcommands

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -250,22 +250,25 @@ func initMain(pid uint, shell string) {
 	}
 }
 
-func apiBashCompleteMain(_ uint, command, word, prevWord string) {
+func apiCompleteWordsMain(_ uint, cword int, words []string) {
 	app := NewApplication()
 	defer app.Close()
+
+	if len(words) == 0 {
+		fatal(fmt.Errorf("command line cannot be empty"))
+	}
 
 	env := os.Environ()
 	dir, err := os.Getwd()
 	verifyFatal(err)
-	executablePath, err := datastore.CanonizeExecutablePath(command, dir, util.GetPathVar(env), util.GetHomeVar(env))
+	executablePath, err := datastore.CanonizeExecutablePath(words[0], dir, util.GetPathVar(env), util.GetHomeVar(env))
 	verifyFatal(err)
 
-	req := server.BashCompletionRequest{
-		ExecutablePath: executablePath,
-		Word:           word,
-		PrevWord:       prevWord,
+	req := server.CompleteWordsRequest{
+		Words: append([]string{executablePath}, words[1:]...),
+		CWord: cword,
 	}
-	rsp := server.BashCompletionResponse{}
+	rsp := server.CompleteWordsResponse{}
 	err = app.Client().Request(&req, &rsp)
 	verifyFatal(err)
 

--- a/datastore/data.go
+++ b/datastore/data.go
@@ -50,7 +50,7 @@ type Command struct {
 
 type Completion struct {
 	Flag    string
-	Context []string
+	Context FlagContext
 }
 
 type HelpPage struct {
@@ -58,6 +58,11 @@ type HelpPage struct {
 	Completions    []Completion
 	CheckSum       string
 	Command        Command
+}
+
+type FlagContext struct {
+	SubCommand []string `json:"sub-command,omitempty"`
+	Framework  string   `json:"framework,omitempty"`
 }
 
 func CheckHelpPage(helpPage *HelpPage) (err error) {
@@ -113,4 +118,20 @@ func CanonizeExecutablePath(name, workDir, pathVar, homeDir string) (canonized s
 	}
 	canonized = filepath.Clean(canonized)
 	return
+}
+
+func IsCommandMatchingContext(command []string, context FlagContext) bool {
+	subCommand := context.SubCommand
+outerLoop:
+	for contextIndex, commandIndex := 0, 1; contextIndex < len(subCommand); {
+		for ; commandIndex < len(command); commandIndex += 1 {
+			if command[commandIndex] == subCommand[contextIndex] {
+				commandIndex += 1
+				contextIndex += 1
+				continue outerLoop
+			}
+		}
+		return false
+	}
+	return true
 }

--- a/datastore/data_test.go
+++ b/datastore/data_test.go
@@ -48,3 +48,15 @@ func TestCanonizeExecutablePath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "/home/user/foo", canonized)
 }
+
+func TestIsCommandMatchingContext(t *testing.T) {
+	require.Equal(t, true,
+		IsCommandMatchingContext([]string{"foo", "bar"}, FlagContext{}),
+	)
+	require.Equal(t, true,
+		IsCommandMatchingContext([]string{"foo", "bar"}, FlagContext{SubCommand: []string{"bar"}}),
+	)
+	require.Equal(t, false,
+		IsCommandMatchingContext([]string{"foo", "bar"}, FlagContext{SubCommand: []string{"bar", "baz"}}),
+	)
+}

--- a/main.go
+++ b/main.go
@@ -115,11 +115,10 @@ func main() {
 
 	apiListClients := api.Command("list-clients", "help list all attached shells").Hidden()
 
-	apiBashComplete := api.Command("bash-complete", "Generate completion list for particular command.").Hidden()
-	addPidArg(apiBashComplete)
-	apiBashCompleteCommand := apiBashComplete.Arg("command", "Command being completed.").Required().String()
-	apiBashCompleteWord := apiBashComplete.Arg("word", "Word being completed.").Required().String()
-	apiBashCompletePrevWord := apiBashComplete.Arg("prev-word", "Word before word being completed.").Required().String()
+	apiCompleteWords := api.Command("complete-words", "Get completions for given command line.").Hidden()
+	addPidArg(apiCompleteWords)
+	apiCompleteWordsCWord := apiCompleteWords.Arg("c-word", "Index of a word being completed.").Required().Int()
+	apiCompleteWordsWords := apiCompleteWords.Arg("words", "Command line being completed.").Required().Strings()
 
 	apiForkedDaemon := api.Command("forked-daemon", "Helper method to run a daemon").Hidden()
 	notifyPid := apiForkedDaemon.Arg("pid", "Pid to notify after command start").Required().Int()
@@ -152,8 +151,8 @@ func main() {
 		apiPollUpdatesMain(pid)
 	case apiPostexec.FullCommand():
 		apiPostexecMain(pid, *apiPostexecCommand)
-	case apiBashComplete.FullCommand():
-		apiBashCompleteMain(pid, *apiBashCompleteCommand, *apiBashCompleteWord, *apiBashCompletePrevWord)
+	case apiCompleteWords.FullCommand():
+		apiCompleteWordsMain(pid, *apiCompleteWordsCWord, *apiCompleteWordsWords)
 	case apiListClients.FullCommand():
 		apiListClientsMain()
 	case apiForkedDaemon.FullCommand():

--- a/parse_doc/argparse.go
+++ b/parse_doc/argparse.go
@@ -107,9 +107,9 @@ func (l *usageLexer) skipSpaces() {
 
 type argparseUsage struct {
 	applicationName         string
-	subcommand              []string
 	positionalArgumentNames []string
 	positionalArguments     []string
+	flagContext             datastore.FlagContext
 }
 
 func parseArgparseUsage(lexer *usageLexer) (usage argparseUsage, err error) {
@@ -123,8 +123,9 @@ func parseArgparseUsage(lexer *usageLexer) (usage argparseUsage, err error) {
 	}
 	usage.applicationName = lexer.Token()
 
-	// Then should go tokens of subcommand up to first '['
+	// Then should go tokens of sub-command up to first '['
 	lexer.Next()
+	usage.flagContext.Framework = "argparse"
 	for {
 		if !lexer.Valid() {
 			err = lexer.Err()
@@ -136,7 +137,7 @@ func parseArgparseUsage(lexer *usageLexer) (usage argparseUsage, err error) {
 		if lexer.TokenIsSyntax() {
 			break
 		}
-		usage.subcommand = append(usage.subcommand, lexer.Token())
+		usage.flagContext.SubCommand = append(usage.flagContext.SubCommand, lexer.Token())
 		lexer.Next()
 	}
 
@@ -243,7 +244,7 @@ func tryParseFlagsParagraph(par *lineTree, usage *argparseUsage, res *parseResul
 		for _, flag := range allFlags {
 			res.completions = append(res.completions, datastore.Completion{
 				Flag:    flag,
-				Context: usage.subcommand,
+				Context: usage.flagContext,
 			})
 		}
 	}
@@ -260,7 +261,7 @@ func extractPositionalArgs(par *lineTree, usage *argparseUsage, res *parseResult
 		}
 		completions = append(completions, datastore.Completion{
 			Flag:    arg,
-			Context: usage.subcommand,
+			Context: usage.flagContext,
 		})
 	}
 	res.completions = append(res.completions, completions...)

--- a/parse_doc/parse_help_test.go
+++ b/parse_doc/parse_help_test.go
@@ -76,7 +76,10 @@ func TestParseQuWriteFileHelp(t *testing.T) {
 	desc, err := ParseHelp("qu", quWriteFileHelp)
 	require.Nil(t, err)
 
-	expectedContext := []string{"write-file"}
+	expectedContext := datastore.FlagContext{
+		SubCommand: []string{"write-file"},
+		Framework:  "argparse",
+	}
 	expected := datastore.HelpPage{
 		ExecutablePath: "qu",
 		Completions: []datastore.Completion{

--- a/server/request.go
+++ b/server/request.go
@@ -30,19 +30,13 @@ type AttachRequest struct {
 type AttachResponse struct {
 }
 
-type BashCompletionRequest struct {
-	CompLine  string
-	CompPoint int
-
-	CompWords []string
-	CompCword int
-
-	ExecutablePath string
-	Word           string
-	PrevWord       string
+type CompleteWordsRequest struct {
+	// First word of the `Words` must be executable path.
+	Words []string
+	CWord int
 }
 
-type BashCompletionResponse struct {
+type CompleteWordsResponse struct {
 	Completions []string
 }
 
@@ -169,7 +163,7 @@ func getMessageName(msg interface{}) string {
 func isRequest(msg interface{}) bool {
 	switch msg.(type) {
 	case *AttachRequest,
-		*BashCompletionRequest,
+		*CompleteWordsRequest,
 		*DetachRequest,
 		*InitScriptRequest,
 		*ListClientsRequest,
@@ -181,7 +175,7 @@ func isRequest(msg interface{}) bool {
 		*UpdateHelpPageRequest:
 		return true
 	case *AttachResponse,
-		*BashCompletionResponse,
+		*CompleteWordsResponse,
 		*DetachResponse,
 		*InitScriptResponse,
 		*ListClientsResponse,

--- a/shells/shells.go
+++ b/shells/shells.go
@@ -73,6 +73,7 @@ function __cod_postexec_zsh() {
 }
 
 function __cod_add_completions() {
+	# -n :: not override existing completions
     compdef -n __cod_complete_zsh "$1"
 }
 
@@ -84,7 +85,11 @@ function __cod_clear_completions() {
 
 function __cod_complete_zsh() {
     local c
-    for c in "${(@f)$(cod api bash-complete -- $$ "${words[1]}" "" "")}" ; do
+	local cs
+	local c_word
+	c_word=$(($CURRENT - 1))
+	cs=("${(f)$(cod api complete-words -- $$ "$c_word" "${words[@]}")}")
+	for c in "${cs[@]}" ; do
         compadd -- "$c"
     done
 	_path_files
@@ -234,7 +239,7 @@ function __cod_complete_bash() {
 	readarray -t FILE_COMPLETIONS < <(compgen -f -X "$FILTEROPT" -- "$2")
 
 	# Generate cod completions.
-    readarray -t COD_COMPLETIONS < <(cod api bash-complete -- $$ "$1" "$2" "$3" 2> /dev/null)
+    readarray -t COD_COMPLETIONS < <(cod api complete-words -- $$ "$COMP_CWORD" "${COMP_WORDS[@]}" 2> /dev/null)
 
 	COMPREPLY=("${FILE_COMPLETIONS[@]}" "${COD_COMPLETIONS[@]}")
 

--- a/test/binaries/argparse-subcommand.py
+++ b/test/binaries/argparse-subcommand.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import argparse
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--parser-argument", help="some help")
+
+    subparsers = parser.add_subparsers()
+    subcommand1_parser = subparsers.add_parser("sub-command1", help="some help")
+    subcommand1_parser.add_argument("--sub-command1-argument")
+
+    subcommand2_parser = subparsers.add_parser("sub-command2", help="some help")
+    subcommand2_parser.add_argument("--sub-command2-argument")
+
+    parser.parse_args()
+

--- a/test/example_configuration_test.go
+++ b/test/example_configuration_test.go
@@ -35,7 +35,7 @@ func TestExampleConfiguration(t *testing.T) {
 	shellPid := strconv.Itoa(shellPidInt)
 	wb.RunCodCmd("init", shellPid, "bash")
 	wb.RunCodCmd("learn", "--", "binaries/cat.py", "--help")
-	out := wb.RunCodCmd("api", "bash-complete", shellPid, "--", "binaries/cat.py", "-", "")
+	out := wb.RunCodCmd("api", "complete-words", shellPid, "--", "1", "binaries/cat.py", "-")
 
 	scan := bufio.NewScanner(strings.NewReader(out))
 	var lines []string

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -33,7 +33,7 @@ func TestUpdateReplace(t *testing.T) {
 	tmpCat := wb.InTmpDataPath("foo")
 	wb.CopyFile("binaries/foo_v1.py", tmpCat)
 	wb.RunCodCmd("learn", "--", tmpCat, "--help")
-	out := wb.RunCodCmd("api", "bash-complete", shellPid, "--", tmpCat, "--", "")
+	out := wb.RunCodCmd("api", "complete-words", shellPid, "--", "1", tmpCat, "--")
 	completions := wb.SplitLines(out)
 	sort.Strings(completions)
 	require.Equal(t, []string{"--bar1", "--foo1"}, completions)
@@ -49,7 +49,7 @@ func TestUpdateReplace(t *testing.T) {
 		},
 		parsed)
 
-	out = wb.RunCodCmd("api", "bash-complete", shellPid, "--", tmpCat, "--", "")
+	out = wb.RunCodCmd("api", "complete-words", shellPid, "--", "1", tmpCat, "--")
 	completions = wb.SplitLines(out)
 	sort.Strings(completions)
 	require.Equal(t, []string{"--bar2", "--foo2", "--qux2"}, completions)


### PR DESCRIPTION
We extract context of the flag from `usage:` and try to hide irrelevant
flags during completion.