### PR TITLE
Convert tabs to spaces

### DIFF
--- a/shells/shells.go
+++ b/shells/shells.go
@@ -239,7 +239,7 @@ function __cod_complete_bash() {
 	readarray -t FILE_COMPLETIONS < <(compgen -f -X "$FILTEROPT" -- "$2")
 
 	# Generate cod completions.
-    readarray -t COD_COMPLETIONS < <(cod api complete-words -- $$ "$COMP_CWORD" "${COMP_WORDS[@]}" 2> /dev/null)
+	readarray -t COD_COMPLETIONS < <(cod api complete-words -- $$ "$COMP_CWORD" "${COMP_WORDS[@]}" 2> /dev/null)
 
 	COMPREPLY=("${FILE_COMPLETIONS[@]}" "${COD_COMPLETIONS[@]}")
 


### PR DESCRIPTION
to generate consistent init script

This fixes the following aesthetic mismatch:
```
        local FILE_COMPLETIONS
        local COD_COMPLETIONS
        # Generate file completions
        readarray -t FILE_COMPLETIONS < <(compgen -f -X "$FILTEROPT" -- "$2")

        # Generate cod completions.
    readarray -t COD_COMPLETIONS < <(cod api complete-words -- $$ "$COMP_CWORD" "${COMP_WORDS[@]}" 2> /dev/null)

        COMPREPLY=("${FILE_COMPLETIONS[@]}" "${COD_COMPLETIONS[@]}")

        local NAME
        local ONLY_EQ=true
        # Now we don't want bash to add trailing space for options that end with '='
        for NAME in "${COD_COMPLETIONS[@]}" ; do
                if [ "${NAME: -1}" != "=" ] ; then

```