### PR TITLE
Use `$fish_pid` instead of `%self`

### DIFF
--- a/README.org
+++ b/README.org
@@ -33,7 +33,7 @@ auto-completions for your shell.
 ** Fish
    Add to =~/.config/fish/config.fish=
    #+BEGIN_SRC
-   cod init %self fish | source
+   cod init $fish_pid fish | source
    #+END_SRC
 
 * Supported shells and operating systems


### PR DESCRIPTION
`$fish_pid` is preferred and available since [fish 3.0b1](https://fishshell.com/docs/current/relnotes.html#:~:text=%24-,fish_pid,-and%20%24last_pid%20are).