### PR TITLE
Move socket to `$XDG_RUNTIME_DIR/cod`

### DIFF
--- a/server/configuration.go
+++ b/server/configuration.go
@@ -53,7 +53,12 @@ func DefaultConfiguration() (cfg Configuration, err error) {
 	}
 	dataDir = path.Join(dataDir, appName)
 
-	runDir := path.Join(dataDir, "var")
+	runDir := os.Getenv("XDG_RUNTIME_DIR")
+	if len(runDir) == 0 {
+		runDir = path.Join(dataDir, "var")
+	} else {
+		runDir = path.Join(runDir, appName)
+	}
 
 	homeDir := os.Getenv("HOME")
 


### PR DESCRIPTION
Currently, cod's socket and lock file are placed at `$XDG_DATA_DIR/cod/var`, which isn't a particularly standard location for them.

The [XDG Base Directory Specification][1] specifies the locations which various files should be stored at. It states:
> There is a single base directory relative to which user-specific runtime files and other file objects should be placed. This directory is defined by the environment variable `$XDG_RUNTIME_DIR`. 

It further states a fallback for when the variable isn't set:
> If `$XDG_RUNTIME_DIR` is not set applications should fall back to a replacement directory with similar capabilities and print a warning message.

This PR changes it so that cod will use `$XDG_RUNTIME_DIR/cod` for the socket & lockfile when `$XDG_RUNTIME_DIR` is set, and will fall back upon `$XDG_DATA_DIR/cod/var`.
Since `$XDG_RUNTIME_DIR` has no default value, falling back upon the old seems like the best choice there.

In my experience, `$XDG_RUNTIME_DIR` is usually set by [pam_systemd][2], and ends up being set to `/run/user/$UID` (which it creates it as a `tmpfs`). However, I'd prefer to just go with general spec compliance here.

I'm probably not the best with Go programming, but I think this implementation should work fine.

[1]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
[2]: https://www.freedesktop.org/software/systemd/man/pam_systemd.html