### PR TITLE
Feature/add command descriptions

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,135 @@
+# Journal-logg
+
+Datum: 2026-05-17
+
+## Syfte
+
+Gå igenom kodbasen, indexera vad projektet gör och hur det är uppbyggt, verifiera bygge och tester, samt dokumentera resultatet i `README.2.md`.
+
+## Genomfört
+
+### Inventering av repo
+
+- Läste filstruktur och identifierade ett Go-projekt med modulnamn `github.com/dim-an/cod`.
+- Centrala rotfiler:
+  - `main.go`: CLI-definition via `kingpin`.
+  - `commands.go`: implementation av publika kommandon och interna API-kommandon.
+  - `daemon.go`: daemonisering, låsfil, socket och processlivscykel.
+  - `application.go`: lat initiering av konfiguration och klient.
+  - `api_attach.go`: separat attach-flöde för shell-integration.
+  - `example_configuration.go`: exempel på TOML-konfiguration.
+  - `ui.go`: terminal- och filbaserad interaktiv UI.
+  - `Makefile`: build, test och install.
+- Identifierade huvudpaket:
+  - `server`: Unix-socket-server, request/response-protokoll, runtime-konfiguration och användarregler.
+  - `datastore`: SQLite-baserad lagring av help pages, kommandon, policies och completions.
+  - `parse_doc`: parsning av `--help`-texter, inklusive argparse-specialfall.
+  - `shells`: shell-tokenisering, quoting och generering av bash/fish/zsh-skript.
+  - `util`: selector/glob-matchning, PATH-sökning, hashing och små hjälpfunktioner.
+  - `test`: end-to-end-tester med temporära XDG-kataloger och fake-shell-processer.
+
+### Funktionell förståelse
+
+- `cod` är en completion-daemon för bash, fish och zsh.
+- Verktyget observerar körda shell-kommandon via shell hooks.
+- Om ett lyckat kommando innehåller `--help` och kommandoraden är enkel föreslår `cod` att lära sig kommandot.
+- Vid inlärning kör daemonen help-kommandot själv, parser help-outputen och sparar flagg-completions i SQLite.
+- Shell-komplettering frågar daemonen via interna `cod api ...`-kommandon.
+- När completions ändras returnerar `api poll-updates` shell-script som först rensar och sedan registrerar om completions.
+
+### Build och verifiering
+
+- Läste `Makefile`.
+- `make build` bygger binären `cod` med:
+  - output: `./cod`
+  - ldflag: `-X main.GitSha=<git-sha>`
+- `make test` kör först build och sedan:
+  - `COD_TEST_BINARY="<repo>/cod" go test ./...`
+- Första testkörningen i sandbox misslyckades eftersom Go build-cache låg utanför workspace:
+  - fel: `open /Users/stefan/Library/Caches/go-build/...: operation not permitted`
+- Körningen upprepades med tillåtelse att använda normal Go build-cache och nätverk för moduler.
+- Slutresultat: `make test` passerade.
+- Go-version i miljön: `go version go1.26.3 darwin/arm64`.
+- Senaste commit vid genomgång: `96c511a8fcec bump dependencies`.
+
+### Testresultat
+
+Verifierat kommando:
+
+```sh
+make test
+```
+
+Resultat:
+
+- `github.com/dim-an/cod`: inga testfiler.
+- `github.com/dim-an/cod/datastore`: ok.
+- `github.com/dim-an/cod/parse_doc`: ok.
+- `github.com/dim-an/cod/server`: inga testfiler.
+- `github.com/dim-an/cod/shells`: ok.
+- `github.com/dim-an/cod/shells/asciitable`: inga testfiler.
+- `github.com/dim-an/cod/test`: ok.
+- `github.com/dim-an/cod/util`: ok.
+
+### Vad som skapas
+
+- Build skapar `./cod`, en lokal binär. Den är ignorerad i `.gitignore`.
+- Testerna skapar temporära arbetskataloger under `/tmp/cod-test-*`.
+- Integrationstesterna sätter `XDG_CONFIG_HOME` och `XDG_DATA_HOME` till temporära kataloger och låter `cod` skapa:
+  - config-kataloger.
+  - data-kataloger.
+  - SQLite-databas `db.sqlite3`.
+  - run-katalog med socket och lockfil.
+  - loggkatalog.
+- Vid lyckade tester städas temporära testkataloger bort av `Workbench.Close`.
+- Vid misslyckade tester skrivs daemonloggar ut innan städning.
+
+### Dokumentation skapad
+
+- Skapade `README.2.md` med sammanhållen dokumentation av projektets:
+  - syfte.
+  - arkitektur.
+  - CLI.
+  - runtime-flöden.
+  - paketindex.
+  - build och install.
+  - teststruktur.
+  - skapade artefakter.
+  - viktiga implementationsegenskaper.
+
+## Noteringar
+
+- `go.mod` anger `go 1.26.0`, och lokal miljö har `go1.26.3`.
+- `Makefile` använder en egen `cd ${THISDIR}`-rad före kommandon. Eftersom varje Makefile-rad körs i separat shell är den raden inte det som styr arbetskatalogen för följande rad, men kommandot kördes ändå korrekt från repo-roten i denna miljö.
+- `release.py` är ett installationssteg som flyttar byggd `cod` till `~/.local/bin/cod`, stoppar eventuell daemon och åter-attachar aktiva klienter.
+
+## Pågående förbättringspass
+
+Startat: 2026-05-17
+
+### Progress
+
+- Klart:
+  - Lagt till `Description` på `datastore.HelpPage`.
+  - Lagt till `Description` på `datastore.Completion`.
+  - Infört SQLite schema v2 med `Description`-kolumner och v1 -> v2-migration.
+  - Lagt till prefix-query för completions via `GetCompletionsByPrefix`.
+  - Uppdaterat parsern så default- och argparse-help kan extrahera kommandobeskrivning och item-beskrivningar.
+  - Uppdaterat parser-tester så de verifierar beskrivningar och deduplicering.
+  - Lagt till datastore-tester för schema v2, migration, beskrivningsfält och prefix-query.
+  - Gjort `cod list` till rich tabell som default.
+  - Lagt till `cod list --format plain` som kompatibilitetsläge för tidigare tab-output.
+  - Lagt till `cod show <selector...>` med detaljvy för kommandon och completions.
+  - Uppdaterat E2E-tester för plain-format och lagt till nya rich list/show-tester.
+  - Kört full `make test`.
+- Pågår:
+  - Inget i detta förbättringspass.
+- Kvar:
+  - Inget i detta förbättringspass.
+
+### Verifiering hittills
+
+- `go test ./parse_doc` passerar.
+- `go test ./datastore` passerar.
+- `go test ./test` passerar.
+- `make test` passerar.

--- a/README.2.md
+++ b/README.2.md
@@ -1,0 +1,337 @@
+# Cod - projektdokumentation
+
+Det här dokumentet är en teknisk genomgång av projektet i denna repo. Den befintliga `README.md` beskriver användning och installation på hög nivå. Denna fil fokuserar på kodens struktur, körflöden, build, tester och vilka artefakter som skapas.
+
+## Sammanfattning
+
+`cod` är ett Go-baserat CLI-verktyg och en shell-completion-daemon för `bash`, `fish` och `zsh`.
+
+Grundidén är:
+
+1. Shell-integration laddas via `cod init <pid> <shell>`.
+2. `cod` startar eller återanvänder en daemon.
+3. Shell hooks anropar interna `cod api ...`-kommandon efter körda kommandon och vid completion.
+4. När ett lyckat, enkelt kommando innehåller `--help` kan `cod` lära sig kommandots options.
+5. Daemonen kör help-kommandot, parser outputen, sparar completions i SQLite och genererar shell-script för uppdaterad completion.
+
+## Teknisk stack
+
+- Språk: Go.
+- Modul: `github.com/dim-an/cod`.
+- CLI-parser: `github.com/alecthomas/kingpin/v2`.
+- Databas: SQLite via `github.com/ncruces/go-sqlite3`.
+- Konfiguration: TOML via `github.com/pelletier/go-toml`.
+- Tester: Go `testing` plus `github.com/stretchr/testify`.
+- IPC: Unix domain socket med JSON-meddelanden.
+
+`go.mod` anger `go 1.26.0`. Verifierad lokal miljö vid genomgång: `go1.26.3 darwin/arm64`.
+
+## CLI och kommandon
+
+Huvudkommandon definieras i `main.go`.
+
+Publika kommandon:
+
+- `learn <subject>...`: lär in completions från ett help-kommando.
+- `list [--format table|plain] [selector...]` eller `ls`: listar sparade kommandon. Default är en tabell med beskrivning och antal completions; `plain` behåller det äldre `id<TAB>kommando`-formatet.
+- `show <selector...>`: visar detaljer för sparade kommandon, inklusive executable path, kommandobeskrivning och completion-beskrivningar.
+- `remove <selector...>` eller `rm`: tar bort sparade kommandon.
+- `update <selector...>`: kör om tidigare help-kommandon och uppdaterar completions.
+- `init <pid> <shell>`: skriver shell-init-script för bash, fish eller zsh och attachar daemonen.
+- `example-config [--create]`: skriver exempelkonfiguration till stdout eller skapar configfilen.
+- `daemon [--foreground]`: startar daemonen.
+
+Dolda interna API-kommandon:
+
+- `api attach`: attachar en shellprocess till daemonen.
+- `api postexec`: analyserar senast körda kommando efter prompt.
+- `api poll-updates`: returnerar shell-script för completion-uppdateringar.
+- `api complete-words`: returnerar completion-kandidater.
+- `api list-clients`: listar attachade shellklienter.
+- `api forked-daemon`: intern daemon-child vid daemonisering.
+- `api bash-clean-completions`: rensar bash-completion-definitioner för ett kommando.
+
+## Runtime-flöde
+
+### Initiering
+
+`cod init <pid> <shell>` gör följande:
+
+1. Skapar logg- och run-kataloger via `server.Configuration`.
+2. Startar daemon om den inte redan kör.
+3. Skickar `AttachRequest` till daemonen med shell, pid och sökväg till `cod`-binären.
+4. Hämtar `InitScriptResponse` från daemonen.
+5. Skriver shell-script till stdout, som användaren normalt sourcar i shell-initfilen.
+
+### Daemon
+
+Daemonen finns i `daemon.go` och `server/server.go`.
+
+- `daemonMain` kan köras i foreground eller daemonisera.
+- `daemonProc` byter arbetskatalog till `/`, tar lock på lockfilen, tar bort gammal socket och startar servern.
+- Servern lyssnar på Unix socket från `Configuration.GetSocketFile`.
+- Varje request är JSON och routas efter request-namn i `serverImpl.handleRequest`.
+- Daemonen håller en karta över attachade shellprocesser och avslutar när sista shellprocessen detachas eller dör.
+
+### Inlärning
+
+Inlärning sker manuellt via `cod learn ...` eller automatiskt efter `--help`-kommandon.
+
+Viktiga steg:
+
+1. Kommandot canonicaliseras till absolut executable path.
+2. Daemonen kör help-kommandot med sparad miljö och arbetskatalog.
+3. Output parseras av `parse_doc.ParseHelp`.
+4. Help page, kommandobeskrivning, completions och completion-beskrivningar sparas i SQLite.
+5. Attachade shellklienter markeras för uppdatering.
+6. `api poll-updates` returnerar reset- och add-script för berörda kommandon.
+
+### Completion
+
+Vid completion anropar shell-scriptet:
+
+```sh
+cod api complete-words -- <pid> <c-word> <words...>
+```
+
+Servern:
+
+1. Hämtar completions för executable path och flagg-prefix från SQLite.
+2. Kontrollerar eventuell subcommand-kontext.
+3. Returnerar matchande flags, en per rad.
+
+## Kodindex
+
+### Rotpaketet `main`
+
+- `main.go`: CLI-definition, versionssträng och dispatch till kommandon.
+- `commands.go`: implementation av `learn`, `list`, `remove`, `update`, `init`, `example-config` och interna API-kommandon.
+- `daemon.go`: daemonisering, forkad daemon, lockfil, signalering och loggtrimning.
+- `application.go`: lat laddning av `server.Configuration` och `server.Client`.
+- `api_attach.go`: attach-flöde som kan starta daemonen innan attach.
+- `example_configuration.go`: texten som `cod example-config` skriver ut.
+- `ui.go`: interaktiv terminal-UI för ja/nej-frågor samt färgad output.
+- `release.py`: installationshjälp som flyttar byggd binär till `~/.local/bin/cod`, dödar daemon och re-attachar klienter.
+- `cod.plugin.zsh`: zsh-plugin som sourcar `cod init $$ zsh` om `cod` finns.
+
+### `server`
+
+Ansvarar för daemonens serverdel, klient, konfiguration och wire-protokoll.
+
+- `configuration.go`: härledda XDG-sökvägar för config, data, socket, lockfil, logg och databas.
+- `client.go`: Unix-socket-klient som skickar JSON-requests.
+- `request.go`: request/response-typer och JSON-marshalling.
+- `server.go`: server-loop, request-routing och all central business logic.
+- `user_configuration.go`: laddar TOML-regler och bestämmer policy per executable.
+- `errors.go`: serialiserbara remote errors och felkoder.
+
+### `datastore`
+
+Ansvarar för persistens.
+
+- `data.go`: domänmodeller som `Command`, `Completion`, `HelpPage`, `HelpPageInfo`, `Policy` och path-canonicalisering.
+- `sqlitedb.go`: SQLite-schema, transaktioner, CRUD och merge-logik för help pages.
+- Databasschemat har tabellerna `HelpPage` och `Completion`.
+- Aktuell schemaversion är v2. Migrationen från v1 lägger till tomma `Description`-fält och bevarar befintliga kommandon/completions.
+- `HelpPage` lagrar executable path, helptext-checksum, command-args-checksum, command JSON, policy och beskrivning.
+- `Completion` lagrar flagga, beskrivning och optional kontext per help page.
+
+### `parse_doc`
+
+Ansvarar för att omvandla help-text till completions.
+
+- `parse_help.go`: väljer parserordning och bygger `datastore.HelpPage`.
+- `argparse.go`: parser specialiserad för Python argparse, inklusive subcommands.
+- `parse_default.go`: generisk parser för flags och enklare subcommand-fall.
+- `textutil.go`: hjälpstrukturer för text, paragrafer och indentering.
+
+Parserordning:
+
+1. argparse-parser.
+2. default-parser.
+
+### `shells`
+
+Ansvarar för shellspecifik integration och parsing av enkla kommandorader.
+
+- `shells.go`: genererar bash-, fish- och zsh-script.
+- `tokenize.go`: tokeniserar shell-kommandon och markerar "scary" syntax.
+- `parse.go`: accepterar endast enkla kommandon och initiala variabelassignments.
+- `quote.go`: shell-quoting.
+- `remove_completions.go`: filtrerar bort bash-completions för specifikt kommando.
+- `asciitable`: små ASCII-konstanter.
+
+### `util`
+
+Gemensamma hjälpfunktioner:
+
+- `find_path.go`: PATH-sökning och miljövariabelhämtning.
+- `selector.go`: selectors/globs för list, remove och update.
+- `util.go`: kataloghantering, hashing, warnings och sort/uniq.
+
+### `test`
+
+End-to-end-tester som kör byggd `cod`-binär.
+
+- `lib.go`: `Workbench` som skapar temporära XDG-kataloger, startar fake-shell-processer och kör `cod`.
+- `binaries/`: små Python-program som används som testkommandon med olika help-output.
+- `learn_test.go`: manuell inlärning, path-upplösning, merge och subcommand-context.
+- `list_test.go`: listning, selector-filter och remove.
+- `poll_update_test.go`: shell update-script efter ändrade completions.
+- `update_test.go`: update, merge, no-op och borttag vid trasigt kommando.
+- `smoke_test.go`: daemon-start och attach/detach-livscykel.
+- `example_configuration_test.go`: validerar exempelkonfigurationen.
+
+## Build
+
+Rekommenderat build-kommando:
+
+```sh
+make build
+```
+
+Det kör:
+
+```sh
+go build -o cod -ldflags "-X main.GitSha=`git rev-parse HEAD`"
+```
+
+Förväntat resultat:
+
+- En körbar binär `./cod` skapas i repo-roten.
+- Binären innehåller aktuell git sha i `main.GitSha`.
+- `cod` är ignorerad i `.gitignore`.
+
+Alternativt kan man köra direkt:
+
+```sh
+go build -o cod
+```
+
+men då sätts inte `GitSha` på samma sätt som i Makefile.
+
+## Install
+
+```sh
+make install
+```
+
+Det kör först build och sedan `python release.py`.
+
+`release.py` förväntar sig att `./cod` finns, flyttar den till `~/.local/bin/cod`, stoppar eventuell körande `cod`-daemon och försöker attacha tidigare klienter igen.
+
+## Tester
+
+Rekommenderat testkommando:
+
+```sh
+make test
+```
+
+Det gör:
+
+1. `make build`.
+2. `COD_TEST_BINARY="<repo>/cod" go test ./...`.
+
+Verifierat resultat 2026-05-17:
+
+```text
+ok   github.com/dim-an/cod/datastore
+ok   github.com/dim-an/cod/parse_doc
+ok   github.com/dim-an/cod/shells
+ok   github.com/dim-an/cod/test
+ok   github.com/dim-an/cod/util
+```
+
+Paket utan testfiler:
+
+- `github.com/dim-an/cod`
+- `github.com/dim-an/cod/server`
+- `github.com/dim-an/cod/shells/asciitable`
+
+### Testtyper
+
+Rena pakettester:
+
+- `datastore/*_test.go`: path-canonicalisering, command context, SQLite CRUD, merge och listning.
+- `parse_doc/*_test.go`: default parser, argparse parser, textutil och specifika help-exempel.
+- `shells/*_test.go`: tokenisering, quoting och bash completion cleanup.
+- `util/selector_test.go`: selector/glob-matchning.
+
+End-to-end-tester:
+
+- Ligger i `test/`.
+- Bygger inte själva binären, utan kräver `COD_TEST_BINARY`.
+- `make test` sätter `COD_TEST_BINARY` till den lokalt byggda `./cod`.
+- Startar fake-shell-processer med `sleep`.
+- Kör `cod init`, `cod learn`, `cod list`, `cod update` och interna `cod api ...`-kommandon.
+
+### Vad testerna skapar
+
+Vid körning skapar `test.Workbench`:
+
+- Temporär systemkatalog: `/tmp/cod-test-*`.
+- Symlinkad arbetskatalog för kortare socket-sökvägar.
+- Per-test-kataloger under `test-data/<TestNamn>` inuti den temporära strukturen.
+- Temporära XDG-kataloger:
+  - `XDG_CONFIG_HOME=<temp>/config`
+  - `XDG_DATA_HOME=<temp>/data`
+
+Runtime skapar sedan under temporär `XDG_DATA_HOME`:
+
+- `cod/db.sqlite3`: SQLite-databas.
+- `cod/var/cod.sock`: Unix socket.
+- `cod/var/cod.lock`: lockfil med daemon-pid.
+- `cod/log/cod.YYYY-MM-DD.log`: daemonlogg.
+
+Vid lyckade tester tas temporär testdata bort. Vid misslyckade tester försöker `Workbench.Close` skriva ut loggfilerna för felsökning.
+
+## Runtime-filer vid normal användning
+
+Konfiguration:
+
+- Om `XDG_CONFIG_HOME` saknas används `~/.config`.
+- User config ligger i `$XDG_CONFIG_HOME/cod/config.toml`.
+
+Data:
+
+- Om `XDG_DATA_HOME` saknas används `~/.local/share`.
+- Databas: `$XDG_DATA_HOME/cod/db.sqlite3`.
+- Socket och lock: `$XDG_DATA_HOME/cod/var/`.
+- Loggar: `$XDG_DATA_HOME/cod/log/`.
+
+## Konfiguration och policy
+
+`cod example-config` skriver ett TOML-exempel.
+
+Viktiga inställningar:
+
+- `command-execution-timeout`: timeout i millisekunder för help-kommandon. Default är 1000.
+- `[[rule]]`: regler per executable selector.
+- `policy` kan vara:
+  - `ask`: fråga användaren.
+  - `trust`: lär automatiskt.
+  - `ignore`: ignorera.
+
+Selectorformer stöds via `util.CompileSelector`, bland annat:
+
+- exakt absolut sökväg.
+- `/path/*`.
+- `/path/**`.
+- basename, till exempel `git`.
+- `~/...` expanderas mot HOME.
+
+## Viktiga beteenden
+
+- Bara enkla kommandorader analyseras automatiskt. Pipes, redirections och annan komplex shellsyntax ignoreras.
+- `--help` efter `--` räknas inte som help-signal, eftersom parsing avbryts vid `--`.
+- Executables canonicaliseras till absolut path innan completions sparas eller slås upp.
+- Completions filtreras både på prefix och eventuell subcommand-kontext.
+- Om ett uppdaterat help-kommando inte längre går att köra tar `update` bort den gamla help page-posten.
+- Daemonen avslutas när sista attachade shellprocessen försvinner.
+
+## Kända observationspunkter
+
+- `Makefile` har separata `cd ${THISDIR}`-rader. Eftersom Make kör varje rad i eget shell påverkar de inte nästa rad. Från repo-roten fungerar kommandona ändå som förväntat.
+- `go test ./...` behöver kunna skriva till Go build-cache. I sandboxad miljö kan det kräva extra tillåtelse.
+- Integrationstesterna använder Unix-processer, signaler, sockets och temporära XDG-kataloger, vilket gör dem mer miljökänsliga än rena pakettester.

--- a/README.md
+++ b/README.md
@@ -1,155 +1,170 @@
 ![](https://img.shields.io/badge/GO-passing-green?style=for-the-badge&logo=Go)
 
-Cod is a completion daemon for ```bash```, ```fish```, and ```zsh```.
+Cod is a completion daemon for `bash`, `fish`, and `zsh`.
 
-It detects usage of ```--help``` commands, parses their output, and generates
+[my forks README](./README.2.md)
+[Journal](./JOURNAL.md)
+
+It detects usage of `--help` commands, parses their output, and generates
 auto-completions for your shell.
 
 ![https://asciinema.org/a/h0SrrNvZVcqoSM4DNyEUrGtQh](https://github.com/TheBearodactyl/assets/blob/main/h0SrrNvZVcqoSM4DNyEUrGtQh.svg)
 
 # Install
 
-  You can either [download](https://github.com/dim-an/cod/releases) or [build](https://github.com/dim-an/cod/blob/master/README.org#Build) the ```cod``` binary
-  for your OS and put it into your ```$PATH```.
+You can either [download](https://github.com/dim-an/cod/releases) or [build](https://github.com/dim-an/cod/blob/master/README.org#Build) the `cod` binary
+for your OS and put it into your `$PATH`.
 
-  After that, you will need to edit your init script (e.g. ```~/.config/fish/config.fish```, ```~/.zshrc```, ```~/.bashrc```) and add a few lines for
-  the daemon to work correctly.
+After that, you will need to edit your init script (e.g. `~/.config/fish/config.fish`, `~/.zshrc`, `~/.bashrc`) and add a few lines for
+the daemon to work correctly.
 
 ### Bash
-   Add the following to your ```~/.bashrc```
-   ```bash
-   source <(cod init $$ bash)
-   ```
+
+Add the following to your `~/.bashrc`
+
+```bash
+source <(cod init $$ bash)
+```
 
 ### Zsh
-   [Make sure](#compsys_init) completion system is initialized.
 
-   Add the following to your ```~/.zshrc```
-   ```zsh
-   source <(cod init $$ zsh)
-   ```
-   Or, you can use a plugin manager like zinit:
-   ```zsh
-   zinit wait lucid for \
-     dim-an/cod
-   ```
+[Make sure](#compsys_init) completion system is initialized.
+
+Add the following to your `~/.zshrc`
+
+```zsh
+source <(cod init $$ zsh)
+```
+
+Or, you can use a plugin manager like zinit:
+
+```zsh
+zinit wait lucid for \
+  dim-an/cod
+```
 
 #### <a name="compsys_init"></a> Initializing zsh completion system
 
-  `cod` requires initialized completion system.
-  In many cases it is already the case (e.g. if you are using oh-my-zsh or similar framework).
+`cod` requires initialized completion system.
+In many cases it is already the case (e.g. if you are using oh-my-zsh or similar framework).
 
-  You can check whether your completion system is already initilized by using `type compdef` command:
-  ```
-  # Completion system IS initialized
-  $ type compdef
-  compdef is a shell function from /usr/share/zsh/functions/Completion/compinit
+You can check whether your completion system is already initilized by using `type compdef` command:
 
-  # Completion system IS NOT initialized
-  $ type compdef
-  compdef not found
-  ```
+```
+# Completion system IS initialized
+$ type compdef
+compdef is a shell function from /usr/share/zsh/functions/Completion/compinit
 
-  If you found that you need to initialize completion system you can do this by:
+# Completion system IS NOT initialized
+$ type compdef
+compdef not found
+```
 
-   - calling `compinit` function in your `.zshrc` before initializing `cod` itself, or
-   - executing `compinstall` command from your shell, it will modify `.zshrc` file for you.
+If you found that you need to initialize completion system you can do this by:
 
-  Also check [zsh documentation](https://zsh.sourceforge.io/Doc/Release/Completion-System.html).
+- calling `compinit` function in your `.zshrc` before initializing `cod` itself, or
+- executing `compinstall` command from your shell, it will modify `.zshrc` file for you.
 
+Also check [zsh documentation](https://zsh.sourceforge.io/Doc/Release/Completion-System.html).
 
 ### Fish
-   Add the following to ```~/.config/fish/config.fish```
-   ```fish
-   cod init $fish_pid fish | source
-   ```
+
+Add the following to `~/.config/fish/config.fish`
+
+```fish
+cod init $fish_pid fish | source
+```
 
 ### Fig
 
-As an alternative, you can also install ```cod``` with [Fig](https://fig.io/plugins/other/cod_dim-an) in ```bash```, ```zsh```, or ```fish``` with just one click.
+As an alternative, you can also install `cod` with [Fig](https://fig.io/plugins/other/cod_dim-an) in `bash`, `zsh`, or `fish` with just one click.
 
 ![https://fig.io/plugins/other/cod_dim-an](https://github.com/TheBearodactyl/assets/blob/main/install-with-fig.svg)
 
 ### Supported shells and operating systems
 
-   - zsh
-   ```cod``` is known to work with latest version of ```zsh``` (tested: ```v5.5.1``` and
-   ```5.7.1```) on macOS and Linux.
+- zsh
+  `cod` is known to work with latest version of `zsh` (tested: `v5.5.1` and
+  `5.7.1`) on macOS and Linux.
 
-   - bash
-   ```cod``` also works with with latest version of ```bash``` (tested: ```4.4.20``` and
-   ```v5.0.11```) on Linux.
+- bash
+  `cod` also works with with latest version of `bash` (tested: `4.4.20` and
+  `v5.0.11`) on Linux.
 
-     Note that default ```bash``` that is bundled with macOS is too old and ```cod```
-     doesn't support it.
+  Note that default `bash` that is bundled with macOS is too old and `cod`
+  doesn't support it.
 
-   - fish
-   ```cod``` works with latest version of ```fish``` (tested: ```v3.1.2```) on Linux
-   (I didn't have a chance to test it on macOS).
-
+- fish
+  `cod` works with latest version of `fish` (tested: `v3.1.2`) on Linux
+  (I didn't have a chance to test it on macOS).
 
 # Building cod
-  It is recommended that you have at least [Go v1.19](https://golang.org/dl/) installed on your machine
-  ```bash
-  git clone https://github.com/dim-an/cod.git
-  cd cod
-  go build
-  ```
 
-  or
+It is recommended that you have at least [Go v1.19](https://golang.org/dl/) installed on your machine
 
-  ```bash
-  go get -u github.com/dim-an/cod
-  ```
+```bash
+git clone https://github.com/dim-an/cod.git
+cd cod
+go build
+```
+
+or
+
+```bash
+go get -u github.com/dim-an/cod
+```
 
 # Overview
-  Cod checks each command you run in the shell. When cod detects usage of
-  ```--help``` flag it asks if you want it to learn this command. If you choose
-  to allow cod to learn this command cod will run command itself parse the
-  output and generate completions based on the ```--help``` output.
+
+Cod checks each command you run in the shell. When cod detects usage of
+`--help` flag it asks if you want it to learn this command. If you choose
+to allow cod to learn this command cod will run command itself parse the
+output and generate completions based on the `--help` output.
 
 ## How cod detects help commands
-   Cod performs following checks to decide if command is help invocation:
-   1. checks if the ```--help``` flag is used
-   2. checks that command is simple i.e. doesn't contain any pipes, file
-     descriptor redirections, and other shell magic
-   3. checks that command exit code is 0.
 
-   If cod cannot automatically detect that your command is help invocation
-   you can use ```learn``` subcommand to learn this command anyway.
+Cod performs following checks to decide if command is help invocation:
+
+1.  checks if the `--help` flag is used
+2.  checks that command is simple i.e. doesn't contain any pipes, file
+    descriptor redirections, and other shell magic
+3.  checks that command exit code is 0.
+
+If cod cannot automatically detect that your command is help invocation
+you can use `learn` subcommand to learn this command anyway.
 
 ## How cod runs help commands
-   Cod always uses absolute paths to run programs. (So it finds the binary in
-   ```$PATH``` or resolves relative path if required). Arguments other than
-   the binary path are left unchanged.
 
-   The current shell environment and current working directory will be
-   used.
+Cod always uses absolute paths to run programs. (So it finds the binary in
+`$PATH` or resolves relative path if required). Arguments other than
+the binary path are left unchanged.
 
-   If the program is successfully executed, cod will store:
-     - the absolute path to binary
-     - any used arguments
-     - the working directory
-     - environment variables
-   This info will be used to update command if required (check:
-   ```cod help update```).
+The current shell environment and current working directory will be
+used.
+
+If the program is successfully executed, cod will store: - the absolute path to binary - any used arguments - the working directory - environment variables
+This info will be used to update command if required (check:
+`cod help update`).
 
 ## How cod parses help output
-   ```cod``` has generic parser that works with most help pages and
-   recognizes flags (starting with ```-```), while not recognizing subcommands.
 
-   It also has a special parser tuned for [the python argparse library](https://docs.python.org/library/argparse.html)
-   that recognizes flags and subcommands.
+`cod` has generic parser that works with most help pages and
+recognizes flags (starting with `-`), while not recognizing subcommands.
+
+It also has a special parser tuned for [the python argparse library](https://docs.python.org/library/argparse.html)
+that recognizes flags and subcommands.
 
 # Configuration
-  Cod will search for the default config file ```$XDG_CONFIG_HOME/cod/config.toml```.
 
-  The config file allows you to specify rules to either ignore or trust specified binaries
+Cod will search for the default config file `$XDG_CONFIG_HOME/cod/config.toml`.
 
-  ```cod example-config``` prints an example configuration to stdout.
+The config file allows you to specify rules to either ignore or trust specified binaries
 
-  ```cod example-config --create``` writes an example config to the default directory of said config file (```$XDG_CONFIG_HOME/cod/config.toml```)
+`cod example-config` prints an example configuration to stdout.
+
+`cod example-config --create` writes an example config to the default directory of said config file (`$XDG_CONFIG_HOME/cod/config.toml`)
 
 # Data directories
-  ```cod``` uses ```$XDG_DATA_HOME/cod``` (default: ```~/.local/share/cod```) to store all
-  generated data files.
+
+`cod` uses `$XDG_DATA_HOME/cod` (default: `~/.local/share/cod`) to store all
+generated data files.

--- a/commands.go
+++ b/commands.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/dim-an/cod/datastore"
 	"github.com/dim-an/cod/server"
@@ -31,27 +32,33 @@ import (
 func summarizeLearning(rsp *server.AddHelpPageResponse) (err error) {
 	var msg string
 	if rsp.Status == datastore.AddHelpPageStatusNew {
-		examples := ""
+		var examples []string
 
 		for i := range rsp.HelpPage.Completions {
-			if i > 0 {
-				examples += " "
-			}
 			cur := fmt.Sprintf("%q", rsp.HelpPage.Completions[i].Flag)
-			if i == 0 || len(examples+cur) < 35 {
-				examples += cur
+			if i == 0 || len(strings.Join(examples, " ")+cur) < 45 {
+				examples = append(examples, cur)
 			} else {
-				examples += fmt.Sprintf("and %v more", len(rsp.HelpPage.Completions)-i)
+				examples = append(examples, fmt.Sprintf("and %v more", len(rsp.HelpPage.Completions)-i))
 				break
 			}
 		}
 
-		msg = fmt.Sprintf("cod: learned completions: %s\n", examples)
+		msg = fmt.Sprintf(
+			"cod: learned %d completions for %s: %s\n",
+			len(rsp.HelpPage.Completions),
+			filepath.Base(rsp.HelpPage.ExecutablePath),
+			strings.Join(examples, " "),
+		)
 	} else {
 		if rsp.Status != datastore.AddHelpPageStatusUpdated {
 			panic(fmt.Errorf("unexpected status: %v", rsp.Status))
 		}
-		msg = fmt.Sprintf("cod: updated completions\n")
+		msg = fmt.Sprintf(
+			"cod: updated %d completions for %s\n",
+			len(rsp.HelpPage.Completions),
+			filepath.Base(rsp.HelpPage.ExecutablePath),
+		)
 	}
 
 	ui := NewUI()
@@ -138,12 +145,12 @@ func apiPostexecMain(pid uint, command string) {
 
 	// https://en.wikipedia.org/wiki/Box_Drawing_(Unicode_block)
 	shortOptions := fmt.Sprintf(
-		"┌──> %v\n└─── cod: learn this command? [yn?] > ",
+		"cod detected a help command:\n  %v\nlearn completions for it? [yn?] > ",
 		strings.Join(rsp.Args, " "),
 	)
 
 	fullOptions := "\n"
-	fullOptions += " y => Yes and enable autoupdates for this commands\n"
+	fullOptions += " y => Yes, learn completions and enable autoupdates for this command\n"
 	fullOptions += " n => Not now\n"
 	fullOptions += " ? => show this help\n"
 	fullOptions += " \n"
@@ -347,7 +354,7 @@ func (b byApplication) Less(i, j int) bool {
 	return lhs.Id < rhs.Id
 }
 
-func listMain(selectors []string) {
+func listMain(selectors []string, format string) {
 	app := NewApplication()
 	defer app.Close()
 
@@ -362,13 +369,87 @@ func listMain(selectors []string) {
 	verifyFatal(err)
 
 	sort.Sort(byApplication(rsp.CommandItems))
+	if format == "plain" {
+		for _, item := range rsp.CommandItems {
+			quoted := "<broken>"
+			if item.Command != nil {
+				quoted = shells.Quote(item.Command.Args)
+			}
+
+			fmt.Printf("%v\t%v\n", item.Id, quoted)
+		}
+		return
+	}
+
+	if len(rsp.CommandItems) == 0 {
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, err = fmt.Fprintln(w, "ID\tCommand\tDescription\tCompletions")
+	verifyFatal(err)
 	for _, item := range rsp.CommandItems {
 		quoted := "<broken>"
 		if item.Command != nil {
 			quoted = shells.Quote(item.Command.Args)
 		}
 
-		fmt.Printf("%v\t%v\n", item.Id, quoted)
+		description := item.Description
+		if description == "" {
+			description = "-"
+		}
+		_, err = fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", item.Id, quoted, description, item.CompletionCount)
+		verifyFatal(err)
+	}
+	err = w.Flush()
+	verifyFatal(err)
+}
+
+func showMain(selectors []string) {
+	app := NewApplication()
+	defer app.Close()
+
+	req := server.ListCommandsRequest{
+		Selectors: selectors,
+	}
+	rsp := server.ListCommandsResponse{}
+	err := app.Client().Request(&req, &rsp)
+	verifyFatal(err)
+
+	sort.Sort(byApplication(rsp.CommandItems))
+	for itemIdx, item := range rsp.CommandItems {
+		if itemIdx > 0 {
+			fmt.Println()
+		}
+		quoted := "<broken>"
+		if item.Command != nil {
+			quoted = shells.Quote(item.Command.Args)
+		}
+		description := item.Description
+		if description == "" {
+			description = "-"
+		}
+		fmt.Printf("ID: %v\n", item.Id)
+		fmt.Printf("Command: %v\n", quoted)
+		fmt.Printf("Executable: %v\n", item.ExecutablePath)
+		fmt.Printf("Description: %v\n", description)
+		fmt.Printf("Completions: %v\n", item.CompletionCount)
+		if len(item.Completions) == 0 {
+			continue
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		_, err = fmt.Fprintln(w, "Completion\tDescription")
+		verifyFatal(err)
+		for _, completion := range item.Completions {
+			completionDescription := completion.Description
+			if completionDescription == "" {
+				completionDescription = "-"
+			}
+			_, err = fmt.Fprintf(w, "%v\t%v\n", completion.Flag, completionDescription)
+			verifyFatal(err)
+		}
+		err = w.Flush()
+		verifyFatal(err)
 	}
 }
 

--- a/datastore/data.go
+++ b/datastore/data.go
@@ -50,15 +50,26 @@ type Command struct {
 }
 
 type Completion struct {
-	Flag    string
-	Context FlagContext
+	Flag        string
+	Description string
+	Context     FlagContext
 }
 
 type HelpPage struct {
 	ExecutablePath string
+	Description    string
 	Completions    []Completion
 	CheckSum       string
 	Command        Command
+}
+
+type HelpPageInfo struct {
+	Id              int64
+	ExecutablePath  string
+	Description     string
+	Command         *Command
+	Completions     []Completion
+	CompletionCount int
 }
 
 type FlagContext struct {

--- a/datastore/sqlitedb.go
+++ b/datastore/sqlitedb.go
@@ -19,23 +19,26 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/dim-an/cod/util"
 	_ "github.com/ncruces/go-sqlite3/driver"
 )
 
-var CurrentSchemaVersion = 1
+var CurrentSchemaVersion = 2
 
 type Storage interface {
 	GetCommandPolicy(args []string) (policy Policy, err error)
 
 	GetAllCompletions() (pages []HelpPage, err error)
 	GetCompletions(path string) (completions []Completion, err error)
+	GetCompletionsByPrefix(path, prefix string) (completions []Completion, err error)
 
 	AddHelpPage(helpPage *HelpPage, policy Policy) (status AddHelpPageStatus, err error)
 
 	// NB. This command might return null pointers in case some help page is broken.
 	ListCommands() (result map[int64]*Command, err error)
+	ListHelpPages() (result []HelpPageInfo, err error)
 
 	RemoveHelpPage(commandId int64) (path string, err error)
 
@@ -94,23 +97,15 @@ func withTransaction(db *sql.DB, f func(tx *sql.Tx) error) (err error) {
 	return
 }
 
-func getCompletionsForExecutable(tx *sql.Tx, executablePath string) (completions []Completion, err error) {
-	completionRows, err := tx.Query(`
-				select Completion.Flag, Completion.Context
-				from Completion inner join HelpPage on Completion.HelpPageId = HelpPage.HelpPageId
-				where HelpPage.ExecutablePath = ?
-			`, executablePath)
-	if err != nil {
-		return
-	}
+func scanCompletions(rows *sql.Rows) (completions []Completion, err error) {
 	defer func() {
-		_ = completionRows.Close()
+		_ = rows.Close()
 	}()
 
-	for completionRows.Next() {
+	for rows.Next() {
 		var contextBytes sql.NullString
 		completion := Completion{}
-		err = completionRows.Scan(&completion.Flag, &contextBytes)
+		err = rows.Scan(&completion.Flag, &contextBytes, &completion.Description)
 		util.VerifyPanic(err)
 		if contextBytes.Valid {
 			err = json.Unmarshal([]byte(contextBytes.String), &completion.Context)
@@ -120,8 +115,32 @@ func getCompletionsForExecutable(tx *sql.Tx, executablePath string) (completions
 		}
 		completions = append(completions, completion)
 	}
-	err = completionRows.Err()
+	err = rows.Err()
 	return
+}
+
+func getCompletionsForExecutable(tx *sql.Tx, executablePath string) (completions []Completion, err error) {
+	completionRows, err := tx.Query(`
+				select Completion.Flag, Completion.Context, Completion.Description
+				from Completion inner join HelpPage on Completion.HelpPageId = HelpPage.HelpPageId
+				where HelpPage.ExecutablePath = ?
+			`, executablePath)
+	if err != nil {
+		return
+	}
+	return scanCompletions(completionRows)
+}
+
+func getCompletionsForHelpPageId(tx *sql.Tx, helpPageId int64) (completions []Completion, err error) {
+	completionRows, err := tx.Query(`
+				select Completion.Flag, Completion.Context, Completion.Description
+				from Completion
+				where Completion.HelpPageId = ?
+			`, helpPageId)
+	if err != nil {
+		return
+	}
+	return scanCompletions(completionRows)
 }
 
 func (s *sqliteStorage) GetCompletions(executablePath string) (completions []Completion, err error) {
@@ -132,6 +151,27 @@ func (s *sqliteStorage) GetCompletions(executablePath string) (completions []Com
 			return
 		}
 		completions = append(completions, cur...)
+		return
+	})
+	return
+}
+
+func escapeLikePrefix(prefix string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return replacer.Replace(prefix) + "%"
+}
+
+func (s *sqliteStorage) GetCompletionsByPrefix(executablePath, prefix string) (completions []Completion, err error) {
+	err = withTransaction(s.db, func(tx *sql.Tx) (err error) {
+		rows, err := tx.Query(`
+				select Completion.Flag, Completion.Context, Completion.Description
+				from Completion inner join HelpPage on Completion.HelpPageId = HelpPage.HelpPageId
+				where HelpPage.ExecutablePath = ? and Completion.Flag like ? escape '\'
+			`, executablePath, escapeLikePrefix(prefix))
+		if err != nil {
+			return
+		}
+		completions, err = scanCompletions(rows)
 		return
 	})
 	return
@@ -216,8 +256,71 @@ func (s *sqliteStorage) ListCommands() (result map[int64]*Command, err error) {
 	return
 }
 
+func (s *sqliteStorage) ListHelpPages() (result []HelpPageInfo, err error) {
+	var items []HelpPageInfo
+	rows, err := s.db.Query(`
+		select
+			HelpPage.HelpPageId,
+			HelpPage.ExecutablePath,
+			HelpPage.Description,
+			HelpPage.CommandJson,
+			count(Completion.CompletionId)
+		from HelpPage
+		left join Completion on Completion.HelpPageId = HelpPage.HelpPageId
+		group by HelpPage.HelpPageId
+	`)
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	for rows.Next() {
+		var commandJson []byte
+		item := HelpPageInfo{}
+		err = rows.Scan(&item.Id, &item.ExecutablePath, &item.Description, &commandJson, &item.CompletionCount)
+		if err != nil {
+			return
+		}
+
+		var command Command
+		err = json.Unmarshal(commandJson, &command)
+		if err != nil {
+			log.Printf("HelpPage %v has broken commandJson field: %v", item.Id, err)
+		} else {
+			item.Command = &command
+		}
+
+		items = append(items, item)
+	}
+	err = rows.Err()
+	if err != nil {
+		return
+	}
+
+	err = withTransaction(s.db, func(tx *sql.Tx) (err error) {
+		for idx := range items {
+			items[idx].Completions, err = getCompletionsForHelpPageId(tx, items[idx].Id)
+			if err != nil {
+				return
+			}
+		}
+		return
+	})
+	result = items
+	return
+}
+
 func (s *sqliteStorage) RemoveHelpPage(helpPageId int64) (executablePath string, err error) {
 	err = withTransaction(s.db, func(tx *sql.Tx) (err error) {
+		err = tx.QueryRow(
+			`select ExecutablePath from HelpPage where HelpPageId = ?`,
+			helpPageId,
+		).Scan(&executablePath)
+		if err != nil {
+			return
+		}
 		err = removeHelpPage(tx, helpPageId)
 		if err != nil {
 			return
@@ -241,7 +344,7 @@ func (s *sqliteStorage) GetCommandPolicy(args []string) (policy Policy, err erro
 
 func (s *sqliteStorage) GetAllCompletions() (pages []HelpPage, err error) {
 	rows, err := s.db.Query(`
-		select HelpPage.ExecutablePath, Completion.Flag
+		select HelpPage.ExecutablePath, HelpPage.Description, Completion.Flag, Completion.Context, Completion.Description
 		from Completion
 		inner join HelpPage on (HelpPage.HelpPageId = Completion.HelpPageId)
 	`)
@@ -252,24 +355,31 @@ func (s *sqliteStorage) GetAllCompletions() (pages []HelpPage, err error) {
 
 	helpPageMap := make(map[string]*HelpPage)
 	for rows.Next() {
-		var executablePath, flag string
-		err = rows.Scan(&executablePath, &flag)
+		var executablePath, helpPageDescription string
+		var contextBytes sql.NullString
+		completion := Completion{}
+		err = rows.Scan(&executablePath, &helpPageDescription, &completion.Flag, &contextBytes, &completion.Description)
 		if err != nil {
 			return
+		}
+		if contextBytes.Valid {
+			err = json.Unmarshal([]byte(contextBytes.String), &completion.Context)
+			if err != nil {
+				return
+			}
 		}
 
 		helpPage, ok := helpPageMap[executablePath]
 		if !ok {
 			helpPage = &HelpPage{
 				ExecutablePath: executablePath,
+				Description:    helpPageDescription,
 			}
 			helpPageMap[executablePath] = helpPage
 		}
 		helpPage.Completions = append(
 			helpPage.Completions,
-			Completion{
-				Flag: flag,
-			},
+			completion,
 		)
 	}
 	err = rows.Err()
@@ -293,7 +403,7 @@ type sqliteStorage struct {
 
 func insertCompletions(tx *sql.Tx, helpPageId int64, completions []Completion) (err error) {
 	completionStatement, err := tx.Prepare(`
-		insert into Completion(HelpPageId, Flag, Context) values (?, ?, ?)
+		insert into Completion(HelpPageId, Flag, Context, Description) values (?, ?, ?, ?)
 	`)
 	if err != nil {
 		return
@@ -305,7 +415,7 @@ func insertCompletions(tx *sql.Tx, helpPageId int64, completions []Completion) (
 		if err != nil {
 			return
 		}
-		_, err = completionStatement.Exec(helpPageId, completion.Flag, contextBytes)
+		_, err = completionStatement.Exec(helpPageId, completion.Flag, contextBytes, completion.Description)
 		if err != nil {
 			return
 		}
@@ -329,8 +439,9 @@ func removeAndMergeConflicting(tx *sql.Tx, executablePath string, commandCheckSu
 			select HelpPageId, CommandJson from HelpPage where ExecutablePath = ? and HelpTextCheckSum = ?
 			`, executablePath, helpPage.CheckSum,
 	).Scan(&helpPageId, &oldCommandJson)
-
-	if err == nil {
+	// FIX QF1002
+	switch err {
+	case nil:
 		var curCommandJson string
 		curCommandJson, err = commandToJson(helpPage.Command)
 		if err != nil {
@@ -352,9 +463,9 @@ func removeAndMergeConflicting(tx *sql.Tx, executablePath string, commandCheckSu
 		if err != nil {
 			return
 		}
-	} else if err == sql.ErrNoRows {
+	case sql.ErrNoRows:
 		err = nil
-	} else {
+	default:
 		return
 	}
 
@@ -362,8 +473,9 @@ func removeAndMergeConflicting(tx *sql.Tx, executablePath string, commandCheckSu
 			select HelpPageId from HelpPage where ExecutablePath = ? and CommandArgsCheckSum = ?
 			`, executablePath, commandCheckSum,
 	).Scan(&helpPageId)
-
-	if err == nil {
+	// FIX QF1002
+	switch err {
+	case nil:
 		if rowIdToReuse == nil || *rowIdToReuse > helpPageId {
 			var tmp = helpPageId
 			rowIdToReuse = &tmp
@@ -372,9 +484,9 @@ func removeAndMergeConflicting(tx *sql.Tx, executablePath string, commandCheckSu
 		if err != nil {
 			return
 		}
-	} else if err == sql.ErrNoRows {
+	case sql.ErrNoRows:
 		err = nil
-	} else {
+	default:
 		return
 	}
 
@@ -394,14 +506,16 @@ func insertHelpPage(tx *sql.Tx, executablePath string, rowIdToReplace *int64, co
 			                     HelpTextCheckSum,
 			                     CommandArgsCheckSum,
 			                     CommandJson,
-			                     Policy
-			) values (?, ?, ?, ?, ?, ?)
+			                     Policy,
+			                     Description
+			) values (?, ?, ?, ?, ?, ?, ?)
 		`, rowIdToReplace,
 		executablePath,
 		helpPage.CheckSum,
 		commandChecksum,
 		helpPageCommandJson,
-		policy)
+		policy,
+		helpPage.Description)
 	if err != nil {
 		return
 	}
@@ -450,9 +564,11 @@ func updateSchema(db *sql.DB) (err error) {
 			HelpPageId     integer not null,
 			Flag           text not null,
 			Context        text,
+			Description    text not null default '',
 			foreign key (HelpPageId) references HelpPage(HelpPageId)
 		)`,
 		`create index Completion_SourceId ON Completion (HelpPageId)`,
+		`create index Completion_SourceId_Flag ON Completion (HelpPageId, Flag)`,
 		`create table HelpPage (
 		    HelpPageId          integer not null primary key autoincrement,
 			ExecutablePath      text,
@@ -460,13 +576,14 @@ func updateSchema(db *sql.DB) (err error) {
 			CommandArgsCheckSum text,
 			CommandJson         text,
 			Policy              text,
+			Description         text not null default '',
 			unique              (ExecutablePath, HelpTextCheckSum),
 			unique              (ExecutablePath, CommandArgsCheckSum)
 		)`,
 		`create index HelpPage_ExecutablePath ON HelpPage (ExecutablePath)`,
 		`create index HelpPage_ExecutablePath_HelpTextCheckSum ON HelpPage (ExecutablePath, HelpTextCheckSum)`,
 		`create index HelpPage_ExecutablePath_CommandArgsCheckSum ON HelpPage (ExecutablePath, CommandArgsCheckSum)`,
-		`PRAGMA user_version = 1`,
+		`PRAGMA user_version = 2`,
 	}
 	err = withTransaction(db, func(tx *sql.Tx) error {
 		for _, stmt := range schemaStatements {
@@ -479,10 +596,25 @@ func updateSchema(db *sql.DB) (err error) {
 	return
 }
 
-func migrateSchema(userVersion int, _ *sql.DB) (err error) {
+func migrateSchema(userVersion int, db *sql.DB) (err error) {
 	switch userVersion {
 	case CurrentSchemaVersion:
 		break
+	case 1:
+		err = withTransaction(db, func(tx *sql.Tx) error {
+			statements := []string{
+				`alter table HelpPage add column Description text not null default ''`,
+				`alter table Completion add column Description text not null default ''`,
+				`create index Completion_SourceId_Flag ON Completion (HelpPageId, Flag)`,
+				`PRAGMA user_version = 2`,
+			}
+			for _, stmt := range statements {
+				if _, err := tx.Exec(stmt); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 	default:
 		panic(fmt.Errorf("unknown db version: %v", userVersion))
 	}

--- a/datastore/sqlitedb_test.go
+++ b/datastore/sqlitedb_test.go
@@ -75,8 +75,6 @@ func TestCRUD(t *testing.T) {
 			ExecutablePath: "/my-test-command",
 			Description:    "test command",
 			Completions: []Completion{
-				{Flag: "-A", Description: "upper"},
-				{Flag: "-a", Description: "lower"},
 				{Flag: "foo", Description: "foo option"},
 				{Flag: "bar", Description: "bar option"},
 				{Flag: "baz"},
@@ -109,8 +107,6 @@ func TestCRUD(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t,
 		[]Completion{
-			{Flag: "-A", Description: "upper"},
-			{Flag: "-a", Description: "lower"},
 			{Flag: "foo", Description: "foo option"},
 			{Flag: "bar", Description: "bar option"},
 			{Flag: "baz"},
@@ -129,22 +125,13 @@ func TestCRUD(t *testing.T) {
 		items,
 	)
 
-	items, err = db.GetCompletionsByPrefix("/my-test-command", "-a")
-	require.Nil(t, err)
-	require.Equal(t,
-		[]Completion{
-			{Flag: "-a", Description: "lower"},
-		},
-		items,
-	)
-
 	helpPages, err := db.ListHelpPages()
 	require.Nil(t, err)
 	sort.Slice(helpPages, func(i, j int) bool {
 		return helpPages[i].ExecutablePath < helpPages[j].ExecutablePath
 	})
 	require.Equal(t, "test command", helpPages[0].Description)
-	require.Equal(t, 6, helpPages[0].CompletionCount)
+	require.Equal(t, 4, helpPages[0].CompletionCount)
 	require.Equal(t, "/my-test-command", helpPages[0].ExecutablePath)
 }
 

--- a/datastore/sqlitedb_test.go
+++ b/datastore/sqlitedb_test.go
@@ -16,6 +16,7 @@ package datastore
 
 import (
 	"crypto/sha1"
+	"database/sql"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -72,9 +73,12 @@ func TestCRUD(t *testing.T) {
 	status, err := db.AddHelpPage(
 		&HelpPage{
 			ExecutablePath: "/my-test-command",
+			Description:    "test command",
 			Completions: []Completion{
-				{Flag: "foo"},
-				{Flag: "bar"},
+				{Flag: "-A", Description: "upper"},
+				{Flag: "-a", Description: "lower"},
+				{Flag: "foo", Description: "foo option"},
+				{Flag: "bar", Description: "bar option"},
 				{Flag: "baz"},
 				{Flag: "qux"},
 			},
@@ -105,13 +109,104 @@ func TestCRUD(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t,
 		[]Completion{
-			{Flag: "foo"},
-			{Flag: "bar"},
+			{Flag: "-A", Description: "upper"},
+			{Flag: "-a", Description: "lower"},
+			{Flag: "foo", Description: "foo option"},
+			{Flag: "bar", Description: "bar option"},
 			{Flag: "baz"},
 			{Flag: "qux"},
 		},
 		items,
 	)
+
+	items, err = db.GetCompletionsByPrefix("/my-test-command", "ba")
+	require.Nil(t, err)
+	require.Equal(t,
+		[]Completion{
+			{Flag: "bar", Description: "bar option"},
+			{Flag: "baz"},
+		},
+		items,
+	)
+
+	items, err = db.GetCompletionsByPrefix("/my-test-command", "-a")
+	require.Nil(t, err)
+	require.Equal(t,
+		[]Completion{
+			{Flag: "-a", Description: "lower"},
+		},
+		items,
+	)
+
+	helpPages, err := db.ListHelpPages()
+	require.Nil(t, err)
+	sort.Slice(helpPages, func(i, j int) bool {
+		return helpPages[i].ExecutablePath < helpPages[j].ExecutablePath
+	})
+	require.Equal(t, "test command", helpPages[0].Description)
+	require.Equal(t, 6, helpPages[0].CompletionCount)
+	require.Equal(t, "/my-test-command", helpPages[0].ExecutablePath)
+}
+
+func TestMigrationV1ToV2(t *testing.T) {
+	tmp, err := ioutil.TempFile("", "cod-sqlite-v1")
+	util.VerifyPanic(err)
+	filename := tmp.Name()
+	require.NoError(t, tmp.Close())
+	defer func() {
+		_ = os.Remove(filename)
+	}()
+
+	rawDb, err := sql.Open("sqlite3", filename)
+	require.NoError(t, err)
+	v1Statements := []string{
+		`create table Completion (
+			CompletionId   integer not null primary key autoincrement,
+			HelpPageId     integer not null,
+			Flag           text not null,
+			Context        text,
+			foreign key (HelpPageId) references HelpPage(HelpPageId)
+		)`,
+		`create index Completion_SourceId ON Completion (HelpPageId)`,
+		`create table HelpPage (
+		    HelpPageId          integer not null primary key autoincrement,
+			ExecutablePath      text,
+			HelpTextCheckSum    text,
+			CommandArgsCheckSum text,
+			CommandJson         text,
+			Policy              text,
+			unique              (ExecutablePath, HelpTextCheckSum),
+			unique              (ExecutablePath, CommandArgsCheckSum)
+		)`,
+		`create index HelpPage_ExecutablePath ON HelpPage (ExecutablePath)`,
+		`create index HelpPage_ExecutablePath_HelpTextCheckSum ON HelpPage (ExecutablePath, HelpTextCheckSum)`,
+		`create index HelpPage_ExecutablePath_CommandArgsCheckSum ON HelpPage (ExecutablePath, CommandArgsCheckSum)`,
+		`insert into HelpPage(ExecutablePath, HelpTextCheckSum, CommandArgsCheckSum, CommandJson, Policy)
+		 values('/legacy', 'legacy-help', 'legacy-command', '{"Args":["/legacy","--help"],"Env":null,"Dir":"/tmp"}', '')`,
+		`insert into Completion(HelpPageId, Flag, Context) values(1, '--legacy', '{}')`,
+		`PRAGMA user_version = 1`,
+	}
+	for _, stmt := range v1Statements {
+		_, err = rawDb.Exec(stmt)
+		require.NoError(t, err)
+	}
+	require.NoError(t, rawDb.Close())
+
+	storage, err := NewSqliteStorage(filename)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, storage.Close())
+	}()
+
+	completions, err := storage.GetCompletions("/legacy")
+	require.NoError(t, err)
+	require.Equal(t, []Completion{{Flag: "--legacy"}}, completions)
+
+	helpPages, err := storage.ListHelpPages()
+	require.NoError(t, err)
+	require.Len(t, helpPages, 1)
+	require.Equal(t, "", helpPages[0].Description)
+	require.Equal(t, 1, helpPages[0].CompletionCount)
 }
 
 func TestAddSamePage(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -72,6 +72,8 @@ func main() {
 	var pid uint
 	var foreground bool
 	var selectors []string
+	var showSelectors []string
+	var listFormat string
 	var createConfig bool
 
 	addShellArg := func(c *kingpin.CmdClause) *kingpin.CmdClause {
@@ -92,7 +94,11 @@ func main() {
 	learnArgs := learn.Arg("subject", "Subject to learn.").Required().Strings()
 
 	list := app.Command("list", "List known commands.").Alias("ls")
+	list.Flag("format", "Output format (table or plain).").Default("table").EnumVar(&listFormat, "table", "plain")
 	list.Arg("selector", "Items to list.").StringsVar(&selectors)
+
+	show := app.Command("show", "Show learned command details.")
+	show.Arg("selector", "Items to show.").Required().StringsVar(&showSelectors)
 
 	remove := app.Command("remove", "Forget known command").Alias("rm")
 	remove.Arg("selector", "Items to remove.").Required().StringsVar(&selectors)
@@ -148,7 +154,9 @@ func main() {
 	case learn.FullCommand():
 		learnMain(*learnArgs)
 	case list.FullCommand():
-		listMain(selectors)
+		listMain(selectors, listFormat)
+	case show.FullCommand():
+		showMain(showSelectors)
 	case init.FullCommand():
 		initMain(pid, shell)
 	case daemon.FullCommand():

--- a/parse_doc/argparse.go
+++ b/parse_doc/argparse.go
@@ -230,9 +230,26 @@ func parseArgparseUsage(lexer *usageLexer) (usage argparseUsage, err error) {
 var argWord = "[_a-zA-Z0-9][-_a-zA-Z0-9]*"
 
 var flagsLineRe = regexp.MustCompile(fmt.Sprintf("^ +-{1,2}%s", argWord))
-var flagRe = regexp.MustCompile(fmt.Sprintf("-{1,2}%s", argWord))
+var _ = regexp.MustCompile(fmt.Sprintf("-{1,2}%s", argWord))
 var argRe = regexp.MustCompile(fmt.Sprintf("^\\s*(%s)(,|\\s|$)", argWord))
 var unnamedSequenceRe = regexp.MustCompile(fmt.Sprintf("^\\s*\\{%s(,%s)*\\}$", argWord, argWord))
+
+func lineTreeDescription(node *lineTree, start int, stripMetavar bool) string {
+	parts := []string{lineDescriptionAfter(node.line, start, stripMetavar)}
+	for idx := range node.children {
+		parts = append(parts, strings.TrimSpace(node.children[idx].line))
+	}
+	return normalizeDescription(parts...)
+}
+
+func optionLineDescription(node *lineTree) (flags []string, description string) {
+	optionLine := parseOptionLine(node.line)
+	parts := []string{optionLine.description}
+	for idx := range node.children {
+		parts = append(parts, strings.TrimSpace(node.children[idx].line))
+	}
+	return optionLine.flags, normalizeDescription(parts...)
+}
 
 func tryParseFlagsParagraph(par *lineTree, usage *argparseUsage, res *parseResult) bool {
 	if len(par.children) == 0 || !flagsLineRe.MatchString(par.children[0].line) {
@@ -240,12 +257,13 @@ func tryParseFlagsParagraph(par *lineTree, usage *argparseUsage, res *parseResul
 	}
 
 	for idx := range par.children {
-		line := par.children[idx].line
-		allFlags := flagRe.FindAllString(line, -1)
+		node := &par.children[idx]
+		allFlags, description := optionLineDescription(node)
 		for _, flag := range allFlags {
-			res.completions = append(res.completions, datastore.Completion{
-				Flag:    flag,
-				Context: usage.flagContext,
+			res.AddCompletion(datastore.Completion{
+				Flag:        flag,
+				Description: description,
+				Context:     usage.flagContext,
 			})
 		}
 	}
@@ -255,17 +273,21 @@ func tryParseFlagsParagraph(par *lineTree, usage *argparseUsage, res *parseResul
 func extractPositionalArgs(par *lineTree, usage *argparseUsage, res *parseResult) bool {
 	var completions []datastore.Completion
 	for idx := range par.children[0].children {
-		line := par.children[0].children[idx].line
+		node := &par.children[0].children[idx]
+		line := node.line
 		arg := argRe.FindStringSubmatch(line)[1]
 		if len(arg) == 0 {
 			return false
 		}
 		completions = append(completions, datastore.Completion{
-			Flag:    arg,
-			Context: usage.flagContext,
+			Flag:        arg,
+			Description: lineTreeDescription(node, strings.Index(line, arg)+len(arg), false),
+			Context:     usage.flagContext,
 		})
 	}
-	res.completions = append(res.completions, completions...)
+	for _, completion := range completions {
+		res.AddCompletion(completion)
+	}
 	return true
 }
 
@@ -340,7 +362,9 @@ func (argparseParser) Parse(context parseContext) (res *parseResult, err error) 
 		return
 	}
 
-	result := &parseResult{}
+	result := &parseResult{
+		description: extractCommandDescription(context.text),
+	}
 	for start := 0; start < len(context.text.lines); {
 		par := context.text.FindIndentedParagraph("arguments:", start)
 		if par == nil {

--- a/parse_doc/argparse_test.go
+++ b/parse_doc/argparse_test.go
@@ -112,29 +112,47 @@ func TestParseArgparseContext(t *testing.T) {
 	require.Equal(
 		t,
 		[]datastore.Completion{
-			{Flag: "--append", Context: argparseContext([]string{"rec"})},
-			{Flag: "--command", Context: argparseContext([]string{"rec"})},
-			{Flag: "--env", Context: argparseContext([]string{"rec"})},
-			{Flag: "--help", Context: argparseContext([]string{"rec"})},
-			{Flag: "--idle-time-limit", Context: argparseContext([]string{"rec"})},
-			{Flag: "--overwrite", Context: argparseContext([]string{"rec"})},
-			{Flag: "--quiet", Context: argparseContext([]string{"rec"})},
-			{Flag: "--raw", Context: argparseContext([]string{"rec"})},
-			{Flag: "--stdin", Context: argparseContext([]string{"rec"})},
-			{Flag: "--title", Context: argparseContext([]string{"rec"})},
-			{Flag: "--yes", Context: argparseContext([]string{"rec"})},
-			{Flag: "-c", Context: argparseContext([]string{"rec"})},
-			{Flag: "-e", Context: argparseContext([]string{"rec"})},
-			{Flag: "-h", Context: argparseContext([]string{"rec"})},
-			{Flag: "-i", Context: argparseContext([]string{"rec"})},
-			{Flag: "-q", Context: argparseContext([]string{"rec"})},
-			{Flag: "-t", Context: argparseContext([]string{"rec"})},
-			{Flag: "-y", Context: argparseContext([]string{"rec"})},
-			// FIXME: this is bug, we should only parse `-y` single time
-			{Flag: "-y", Context: argparseContext([]string{"rec"})},
+			{Flag: "--append", Description: "append to existing recording", Context: argparseContext([]string{"rec"})},
+			{Flag: "--command", Description: "command to record, defaults to $SHELL", Context: argparseContext([]string{"rec"})},
+			{Flag: "--env", Description: "list of environment variables to capture, defaults to SHELL,TERM", Context: argparseContext([]string{"rec"})},
+			{Flag: "--help", Description: "show this help message and exit", Context: argparseContext([]string{"rec"})},
+			{Flag: "--idle-time-limit", Description: "limit recorded idle time to given number of seconds", Context: argparseContext([]string{"rec"})},
+			{Flag: "--overwrite", Description: "overwrite the file if it already exists", Context: argparseContext([]string{"rec"})},
+			{Flag: "--quiet", Description: "be quiet, suppress all notices/warnings (implies -y)", Context: argparseContext([]string{"rec"})},
+			{Flag: "--raw", Description: "save only raw stdout output", Context: argparseContext([]string{"rec"})},
+			{Flag: "--stdin", Description: "enable stdin recording, disabled by default", Context: argparseContext([]string{"rec"})},
+			{Flag: "--title", Description: "title of the asciicast", Context: argparseContext([]string{"rec"})},
+			{Flag: "--yes", Description: "answer \"yes\" to all prompts (e.g. upload confirmation)", Context: argparseContext([]string{"rec"})},
+			{Flag: "-c", Description: "command to record, defaults to $SHELL", Context: argparseContext([]string{"rec"})},
+			{Flag: "-e", Description: "list of environment variables to capture, defaults to SHELL,TERM", Context: argparseContext([]string{"rec"})},
+			{Flag: "-h", Description: "show this help message and exit", Context: argparseContext([]string{"rec"})},
+			{Flag: "-i", Description: "limit recorded idle time to given number of seconds", Context: argparseContext([]string{"rec"})},
+			{Flag: "-q", Description: "be quiet, suppress all notices/warnings (implies -y)", Context: argparseContext([]string{"rec"})},
+			{Flag: "-t", Description: "title of the asciicast", Context: argparseContext([]string{"rec"})},
+			{Flag: "-y", Description: "answer \"yes\" to all prompts (e.g. upload confirmation)", Context: argparseContext([]string{"rec"})},
 		},
 		parseResult.completions,
 	)
+}
+
+func TestParseArgparseDescription(t *testing.T) {
+	desc, err := ParseHelp([]string{"/usr/bin/asciinema", "--help"}, asciicinemaHelp)
+	require.NoError(t, err)
+	require.Equal(t, "Record and share your terminal sessions, the right way.", desc.Description)
+	require.Contains(t, desc.Completions, datastore.Completion{
+		Flag:        "rec",
+		Description: "Record terminal session",
+		Context: datastore.FlagContext{
+			Framework: "argparse",
+		},
+	})
+	require.Contains(t, desc.Completions, datastore.Completion{
+		Flag:        "--version",
+		Description: "show program's version number and exit",
+		Context: datastore.FlagContext{
+			Framework: "argparse",
+		},
+	})
 }
 
 var asciicinemaHelp = `usage: asciinema [-h] [--version] {rec,play,cat,upload,auth} ...

--- a/parse_doc/parse_default.go
+++ b/parse_doc/parse_default.go
@@ -29,6 +29,7 @@ var javaStyleFlagRegexp = regexp.MustCompile(`^-[[:word:]]{2,}$`)
 var indentedSubCommandRegexp = regexp.MustCompile(`^\s+([-[:word:]]+)`)
 var subCommandRegexp = regexp.MustCompile(`^[[:word:]][-[:word:]]*$`)
 var wordRegexp = regexp.MustCompile(`\S+`)
+var optionDescriptionSeparatorRegexp = regexp.MustCompile(`\s{2,}`)
 
 type defaultParser struct{}
 
@@ -42,6 +43,60 @@ func (defaultParser) Name() string {
 
 func isJavaStyleFlag(flag string) bool {
 	return javaStyleFlagRegexp.MatchString(flag)
+}
+
+type parsedOptionLine struct {
+	flags       []string
+	description string
+}
+
+func isOptionSeparator(s string) bool {
+	fields := strings.FieldsFunc(s, func(r rune) bool {
+		switch r {
+		case ' ', '\t', ',', '|', '[', ']':
+			return true
+		default:
+			return false
+		}
+	})
+	for _, field := range fields {
+		if !isMetavar(field) {
+			return false
+		}
+	}
+	return true
+}
+
+func parseOptionLine(line string) parsedOptionLine {
+	matches := flagRegexp.FindAllStringSubmatchIndex(line, -1)
+	if len(matches) == 0 {
+		return parsedOptionLine{}
+	}
+
+	included := matches[:1]
+	for idx := 1; idx < len(matches); idx++ {
+		prevEnd := included[len(included)-1][3]
+		curBegin := matches[idx][2]
+		if !isOptionSeparator(line[prevEnd:curBegin]) {
+			break
+		}
+		included = append(included, matches[idx])
+	}
+
+	var flags []string
+	for _, match := range included {
+		flags = append(flags, line[match[2]:match[3]])
+	}
+
+	descriptionStart := included[len(included)-1][3]
+	if separator := optionDescriptionSeparatorRegexp.FindStringIndex(line[descriptionStart:]); separator != nil {
+		descriptionStart += separator[1]
+	}
+
+	return parsedOptionLine{
+		flags:       flags,
+		description: lineDescriptionAfter(line, descriptionStart, true),
+	}
 }
 
 func parseUsageSubCommand(args []string, text *preparedText) (res []string) {
@@ -70,7 +125,8 @@ func parseUsageSubCommand(args []string, text *preparedText) (res []string) {
 
 	// Then we make sure that the first word after usage is name of application (we check only basename).
 	executableBase := path.Base(args[0])
-	if words == nil || len(words) < 1 {
+
+	if len(words) < 1 {
 		return
 	}
 
@@ -118,18 +174,34 @@ outerLoop:
 }
 
 func (defaultParser) Parse(context parseContext) (res *parseResult, err error) {
-	res = &parseResult{}
+	res = &parseResult{
+		description: extractCommandDescription(context.text),
+	}
 
 	flagContext := datastore.FlagContext{
 		SubCommand: parseUsageSubCommand(context.args, context.text),
 	}
 
-	var completions []datastore.Completion
 	var discoveredFlagMap = make(map[string]bool)
 	var discoveredFlags []string
-	for _, line := range context.text.lines {
-		flagsMatch := flagRegexp.FindAllStringSubmatch(line, -1)
-		for _, match := range flagsMatch {
+	var descriptions = make(map[string]string)
+	for lineIdx, line := range context.text.lines {
+		optionLine := parseOptionLine(line)
+		description := normalizeDescription(
+			optionLine.description,
+			normalizeDescription(collectIndentedDescription(context.text.lines, lineIdx, computeIndent(line))...),
+		)
+		for _, flag := range optionLine.flags {
+			if !discoveredFlagMap[flag] {
+				discoveredFlags = append(discoveredFlags, flag)
+				discoveredFlagMap[flag] = true
+			}
+			if descriptions[flag] == "" {
+				descriptions[flag] = description
+			}
+		}
+		allMatches := flagRegexp.FindAllStringSubmatch(line, -1)
+		for _, match := range allMatches {
 			flag := match[1]
 			if !discoveredFlagMap[flag] {
 				discoveredFlags = append(discoveredFlags, flag)
@@ -153,7 +225,11 @@ func (defaultParser) Parse(context parseContext) (res *parseResult, err error) {
 		if isGnuLike && isJavaStyleFlag(flag) {
 			continue
 		}
-		completions = append(completions, datastore.Completion{Flag: flag, Context: flagContext})
+		res.AddCompletion(datastore.Completion{
+			Flag:        flag,
+			Description: descriptions[flag],
+			Context:     flagContext,
+		})
 	}
 
 	// Now we are going to search for sub-commands.
@@ -197,14 +273,16 @@ func (defaultParser) Parse(context parseContext) (res *parseResult, err error) {
 					continue
 				}
 				subCommand := m[1]
-				completions = append(completions, datastore.Completion{Flag: subCommand, Context: flagContext})
+				res.AddCompletion(datastore.Completion{
+					Flag:        subCommand,
+					Description: lineDescriptionAfter(line, strings.Index(line, subCommand)+len(subCommand), false),
+					Context:     flagContext,
+				})
 			} else if indent < currentParagraphIndent {
 				state = Outer
 			} // else if indent > currentParagraphIndent { continue }
 		}
 		prevIndent = indent
 	}
-
-	res.completions = completions
 	return
 }

--- a/parse_doc/parse_help.go
+++ b/parse_doc/parse_help.go
@@ -62,6 +62,7 @@ func ParseHelp(args []string, help string) (*datastore.HelpPage, error) {
 
 	helpPage := datastore.HelpPage{
 		ExecutablePath: args[0],
+		Description:    res.description,
 		Completions:    res.completions,
 	}
 	helpPage.CheckSum = fmt.Sprintf("%x", sha1.Sum([]byte(help)))

--- a/parse_doc/parse_help_test.go
+++ b/parse_doc/parse_help_test.go
@@ -45,11 +45,12 @@ func TestParseCatHelp(t *testing.T) {
 
 	expected := datastore.HelpPage{
 		ExecutablePath: "cat",
+		Description:    "Concatenate FILE(s) to standard output.",
 		Completions: []datastore.Completion{
-			{Flag: "-A"},
-			{Flag: "--show-all"},
-			{Flag: "-e"},
-			{Flag: "--help"},
+			{Flag: "-A", Description: "equivalent to -vET"},
+			{Flag: "--show-all", Description: "equivalent to -vET"},
+			{Flag: "-e", Description: "equivalent to -vE"},
+			{Flag: "--help", Description: "display this help and exit"},
 		},
 		CheckSum: "4a8d01dde2483ad006b8f5ac2f599f9369287730",
 	}
@@ -82,10 +83,10 @@ func TestParseQuWriteFileHelp(t *testing.T) {
 	expected := datastore.HelpPage{
 		ExecutablePath: "qu",
 		Completions: []datastore.Completion{
-			{Flag: "-h", Context: expectedContext},
-			{Flag: "--help", Context: expectedContext},
-			{Flag: "--destination", Context: expectedContext},
-			{Flag: "--compute", Context: expectedContext},
+			{Flag: "-h", Description: "show this help message and exit", Context: expectedContext},
+			{Flag: "--help", Description: "show this help message and exit", Context: expectedContext},
+			{Flag: "--destination", Description: "destination see also http://example.com/", Context: expectedContext},
+			{Flag: "--compute", Description: "compute file content", Context: expectedContext},
 		},
 		CheckSum: "54e9e119f4205bdde6a9315db1a67571385a6cf2",
 	}
@@ -233,9 +234,9 @@ func TestMultipleFlagOccurrences(t *testing.T) {
 	expected := datastore.HelpPage{
 		ExecutablePath: "foo",
 		Completions: []datastore.Completion{
-			{Flag: "--help"},
-			{Flag: "--foo"},
-			{Flag: "--bar"},
+			{Flag: "--help", Description: "show help"},
+			{Flag: "--foo", Description: "some stuff"},
+			{Flag: "--bar", Description: "other stuff (see also --foo)"},
 		},
 		CheckSum: "918a6cca7affef42dd94d07a5073676f0a43e3c7",
 	}
@@ -258,14 +259,14 @@ func TestJavaStyleInclusion(t *testing.T) {
 	expected := datastore.HelpPage{
 		ExecutablePath: "foo",
 		Completions: []datastore.Completion{
-			{Flag: "--help"},
-			{Flag: "-v"},
-			{Flag: "--verbose"},
-			{Flag: "-E"},
-			{Flag: "--expand"},
-			{Flag: "-T"},
-			{Flag: "--text"},
-			{Flag: "-a"},
+			{Flag: "--help", Description: "show help"},
+			{Flag: "-v", Description: "be verbose"},
+			{Flag: "--verbose", Description: "be verbose"},
+			{Flag: "-E", Description: "expand something"},
+			{Flag: "--expand", Description: "expand something"},
+			{Flag: "-T", Description: "expand something"},
+			{Flag: "--text", Description: "expand something"},
+			{Flag: "-a", Description: "same as -vET"},
 		},
 		CheckSum: "6776c5b37b6af1554b1af65fd95275117a379682",
 	}
@@ -288,11 +289,11 @@ func TestJavaStyle(t *testing.T) {
 	expected := datastore.HelpPage{
 		ExecutablePath: "foo",
 		Completions: []datastore.Completion{
-			{Flag: "-h"},
-			{Flag: "-v"},
-			{Flag: "-E"},
-			{Flag: "-T"},
-			{Flag: "-a"},
+			{Flag: "-h", Description: "show help"},
+			{Flag: "-v", Description: "be verbose"},
+			{Flag: "-E", Description: "expand something"},
+			{Flag: "-T", Description: "expand something"},
+			{Flag: "-a", Description: "same as -vET"},
 			{Flag: "-vET"}, // it might be
 		},
 		CheckSum: "7665663f96338ab2dee80c5e0c06b5b6e9c10533",
@@ -313,8 +314,8 @@ func TestOptionInVeryBeginningOfLine(t *testing.T) {
 	expected := datastore.HelpPage{
 		ExecutablePath: "foo",
 		Completions: []datastore.Completion{
-			{Flag: "-h"},
-			{Flag: "--foo"}, // it might be
+			{Flag: "-h", Description: "show help"},
+			{Flag: "--foo", Description: "foo option"}, // it might be
 		},
 		CheckSum: "ed099ed53e5217b2a71ab207209c309b44acf988",
 	}

--- a/parse_doc/textutil.go
+++ b/parse_doc/textutil.go
@@ -16,6 +16,7 @@ package parse_doc
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"io"
 	"strings"
@@ -40,7 +41,29 @@ func makeParseContext(args []string, helpText string) (ctx parseContext, err err
 }
 
 type parseResult struct {
+	description string
 	completions []datastore.Completion
+}
+
+func completionKey(completion datastore.Completion) string {
+	contextBytes, err := json.Marshal(completion.Context)
+	if err != nil {
+		panic(err)
+	}
+	return completion.Flag + "\x00" + string(contextBytes)
+}
+
+func (res *parseResult) AddCompletion(completion datastore.Completion) {
+	key := completionKey(completion)
+	for idx := range res.completions {
+		if completionKey(res.completions[idx]) == key {
+			if res.completions[idx].Description == "" && completion.Description != "" {
+				res.completions[idx].Description = completion.Description
+			}
+			return
+		}
+	}
+	res.completions = append(res.completions, completion)
 }
 
 type preparedText struct {
@@ -79,7 +102,6 @@ func (pt *preparedText) FindFirstLine(pattern string) int {
 	return -1
 }
 
-//
 // Find first empty line starting from line `start'.
 func (pt *preparedText) ParagraphEnd(start int) int {
 	cur := start
@@ -144,4 +166,105 @@ func computeIndent(line string) int {
 		}
 	}
 	return -1
+}
+
+func normalizeDescription(parts ...string) string {
+	var cleaned []string
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			cleaned = append(cleaned, part)
+		}
+	}
+	return strings.Join(cleaned, " ")
+}
+
+func isMetavar(s string) bool {
+	if s == "" {
+		return false
+	}
+	s = strings.Trim(s, "[]{}(),")
+	for _, r := range s {
+		if r == '_' || r == '-' || ('0' <= r && r <= '9') {
+			continue
+		}
+		if !unicode.IsUpper(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func lineDescriptionAfter(line string, start int, stripMetavar bool) string {
+	if start >= len(line) {
+		return ""
+	}
+	tail := strings.TrimSpace(line[start:])
+	if stripMetavar {
+		fields := strings.Fields(tail)
+		if len(fields) == 1 && isMetavar(fields[0]) {
+			tail = ""
+		} else if len(fields) > 1 && isMetavar(fields[0]) {
+			tail = strings.TrimSpace(strings.TrimPrefix(tail, fields[0]))
+		}
+	}
+	return tail
+}
+
+func collectIndentedDescription(lines []string, start int, baseIndent int) (description []string) {
+	for idx := start + 1; idx < len(lines); idx++ {
+		line := lines[idx]
+		indent := computeIndent(line)
+		if indent < 0 {
+			break
+		}
+		if indent <= baseIndent {
+			break
+		}
+		if strings.Contains(line, "-") {
+			break
+		}
+		description = append(description, strings.TrimSpace(line))
+	}
+	return
+}
+
+func extractCommandDescription(text *preparedText) string {
+	usageStart := text.FindFirstLine("usage:")
+	if usageStart < 0 {
+		usageStart = text.FindFirstLine("Usage:")
+	}
+	if usageStart < 0 {
+		return ""
+	}
+
+	usageEnd := text.ParagraphEnd(usageStart)
+	var usageDescriptions []string
+	for idx := usageStart + 1; idx < usageEnd; idx++ {
+		line := strings.TrimSpace(text.lines[idx])
+		if line != "" && !strings.HasPrefix(line, "[") && computeIndent(text.lines[idx]) == 0 {
+			usageDescriptions = append(usageDescriptions, line)
+		}
+	}
+	if len(usageDescriptions) > 0 {
+		return normalizeDescription(usageDescriptions...)
+	}
+
+	for idx := usageEnd + 1; idx < len(text.lines); idx++ {
+		line := strings.TrimSpace(text.lines[idx])
+		if line == "" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(line, "-") ||
+			computeIndent(text.lines[idx]) > 0 ||
+			strings.HasSuffix(lower, "arguments:") ||
+			strings.HasSuffix(lower, "options:") ||
+			strings.HasSuffix(lower, "commands:") {
+			return ""
+		}
+		end := text.ParagraphEnd(idx)
+		return normalizeDescription(text.lines[idx:end]...)
+	}
+	return ""
 }

--- a/server/request.go
+++ b/server/request.go
@@ -70,7 +70,11 @@ type ListCommandsResponseItem struct {
 	Id int64
 
 	// In rare cases Command might be empty.
-	Command *datastore.Command
+	Command         *datastore.Command
+	ExecutablePath  string
+	Description     string
+	Completions     []datastore.Completion
+	CompletionCount int
 }
 type ListCommandsResponse struct {
 	CommandItems []ListCommandsResponseItem

--- a/server/server.go
+++ b/server/server.go
@@ -309,15 +309,15 @@ func (s *serverImpl) handleCompleteWords(req *CompleteWordsRequest, _ *util.Warn
 		return
 	}
 
-	completions, err := s.storage.GetCompletions(req.Words[0])
-	if err != nil {
-		return
-	}
-
 	cWord := req.CWord
 	var word string
 	if 1 <= cWord && cWord < len(req.Words) {
 		word = req.Words[cWord]
+	}
+
+	completions, err := s.storage.GetCompletionsByPrefix(req.Words[0], word)
+	if err != nil {
+		return
 	}
 
 	if cWord < 1 {
@@ -388,7 +388,7 @@ func (s *serverImpl) handleListClients(_ *ListClientsRequest, _ *util.Warner) (r
 	return
 }
 
-var numberRe = regexp.MustCompile("^\\d+$")
+var numberRe = regexp.MustCompile(`^\d+$`)
 
 func (s *serverImpl) handleListCommands(req *ListCommandsRequest, _ *util.Warner) (rsp ListCommandsResponse, err error) {
 	idFilter := make(map[int64]bool)
@@ -412,18 +412,18 @@ func (s *serverImpl) handleListCommands(req *ListCommandsRequest, _ *util.Warner
 		}
 	}
 
-	commands, err := s.storage.ListCommands()
+	helpPages, err := s.storage.ListHelpPages()
 	if err != nil {
 		return
 	}
 
-	for id, command := range commands {
+	for _, helpPage := range helpPages {
 		take := false
-		if _, ok := idFilter[id]; ok {
+		if _, ok := idFilter[helpPage.Id]; ok {
 			take = true
-		} else if command != nil && len(command.Args) > 0 {
+		} else if helpPage.Command != nil && len(helpPage.Command.Args) > 0 {
 			for _, g := range globs {
-				if g.MatchString(command.Args[0]) {
+				if g.MatchString(helpPage.Command.Args[0]) {
 					take = true
 					break
 				}
@@ -432,8 +432,12 @@ func (s *serverImpl) handleListCommands(req *ListCommandsRequest, _ *util.Warner
 
 		if take {
 			item := ListCommandsResponseItem{
-				Id:      id,
-				Command: command,
+				Id:              helpPage.Id,
+				Command:         helpPage.Command,
+				ExecutablePath:  helpPage.ExecutablePath,
+				Description:     helpPage.Description,
+				Completions:     helpPage.Completions,
+				CompletionCount: helpPage.CompletionCount,
 			}
 			rsp.CommandItems = append(rsp.CommandItems, item)
 		}

--- a/test/learn_test.go
+++ b/test/learn_test.go
@@ -92,7 +92,7 @@ func TestLearnUpdateShorter(t *testing.T) {
 	wb.RunCodCmd("init", shellPid, "bash")
 	wb.RunCodCmd("learn", "--", "binaries/cat.py", "--foo", "--help")
 
-	commands := wb.ParseCodListCommands(wb.RunCodCmd("list"))
+	commands := wb.ParseCodListCommands(wb.RunCodCmd("list", "--format", "plain"))
 	require.Equal(t,
 		[]string{
 			"binaries/cat.py --foo --help",
@@ -102,7 +102,7 @@ func TestLearnUpdateShorter(t *testing.T) {
 
 	wb.RunCodCmd("learn", "--", "binaries/cat.py", "--help")
 
-	commands = wb.ParseCodListCommands(wb.RunCodCmd("list"))
+	commands = wb.ParseCodListCommands(wb.RunCodCmd("list", "--format", "plain"))
 	require.Equal(t,
 		[]string{
 			"binaries/cat.py --help",
@@ -131,7 +131,7 @@ func TestLearnFromPATH(t *testing.T) {
 	}
 	wb.RunCodCmdModifiedEnv(modifiedEnv, "learn", "--", "cat.py", "--help")
 
-	out := wb.RunCodCmd("list")
+	out := wb.RunCodCmd("list", "--format", "plain")
 	parsed := wb.ParseCodListMap(out)
 	require.Equal(
 		t,
@@ -163,7 +163,7 @@ func TestMergeLearn(t *testing.T) {
 	}
 	wb.RunCodCmdModifiedEnv(modifiedEnv, "learn", "--", "foo", "--help")
 
-	out := wb.RunCodCmd("list")
+	out := wb.RunCodCmd("list", "--format", "plain")
 	parsed := wb.ParseCodListMap(out)
 	require.Equal(
 		t,
@@ -179,7 +179,7 @@ func TestMergeLearn(t *testing.T) {
 
 	wb.RunCodCmdModifiedEnv(modifiedEnv, "learn", "--", "foo", "--some-arg", "--help")
 
-	out = wb.RunCodCmd("list")
+	out = wb.RunCodCmd("list", "--format", "plain")
 	parsed = wb.ParseCodListMap(out)
 	require.Equal(
 		t,
@@ -193,7 +193,7 @@ func TestMergeLearn(t *testing.T) {
 	// Now we use `foo --help` again and this should merge our commands.
 	wb.RunCodCmdModifiedEnv(modifiedEnv, "learn", "--", "foo", "--help")
 
-	out = wb.RunCodCmd("list")
+	out = wb.RunCodCmd("list", "--format", "plain")
 	parsed = wb.ParseCodListMap(out)
 	require.Equal(
 		t,

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -33,7 +33,7 @@ func TestLearnList(t *testing.T) {
 	wb.RunCodCmd("learn", "--", "binaries/cat.py", "--help")
 	wb.RunCodCmd("learn", "--", "binaries/naval-fate.py", "--help")
 
-	out := wb.RunCodCmd("list")
+	out := wb.RunCodCmd("list", "--format", "plain")
 
 	commands := wb.ParseCodListCommands(out)
 
@@ -57,7 +57,7 @@ func TestLearnListRemove(t *testing.T) {
 	wb.RunCodCmd("learn", "--", "binaries/cat.py", "--help")
 	wb.RunCodCmd("learn", "--", "binaries/naval-fate.py", "--help")
 
-	out := wb.RunCodCmd("list")
+	out := wb.RunCodCmd("list", "--format", "plain")
 
 	commands := wb.ParseCodListCommands(out)
 
@@ -70,7 +70,7 @@ func TestLearnListRemove(t *testing.T) {
 	)
 
 	wb.RunCodCmd("remove", "1")
-	out = wb.RunCodCmd("list")
+	out = wb.RunCodCmd("list", "--format", "plain")
 	commands = wb.ParseCodListCommands(out)
 
 	require.Equal(t,
@@ -81,7 +81,7 @@ func TestLearnListRemove(t *testing.T) {
 	)
 
 	wb.RunCodCmd("remove", "2")
-	out = wb.RunCodCmd("list")
+	out = wb.RunCodCmd("list", "--format", "plain")
 	require.Equal(t, "", out)
 }
 
@@ -96,7 +96,7 @@ func TestLearnListBasenameSelector(t *testing.T) {
 	wb.RunCodCmd("learn", "--", "binaries/cat.py", "--help")
 	wb.RunCodCmd("learn", "--", "binaries/naval-fate.py", "--help")
 
-	out := wb.RunCodCmd("list", "cat.py")
+	out := wb.RunCodCmd("list", "--format", "plain", "cat.py")
 
 	commands := wb.ParseCodListCommands(out)
 
@@ -122,7 +122,7 @@ func TestLearnListPathSelector(t *testing.T) {
 	abs, err := filepath.Abs("binaries/naval-fate.py")
 	require.Nil(t, err)
 
-	out := wb.RunCodCmd("list", abs)
+	out := wb.RunCodCmd("list", "--format", "plain", abs)
 
 	commands := wb.ParseCodListCommands(out)
 
@@ -145,7 +145,7 @@ func TestLearnListIdSelector(t *testing.T) {
 	wb.RunCodCmd("learn", "--", "binaries/cat.py", "--help")
 	wb.RunCodCmd("learn", "--", "binaries/naval-fate.py", "--help")
 
-	out := wb.RunCodCmd("list", "2")
+	out := wb.RunCodCmd("list", "--format", "plain", "2")
 
 	commands := wb.ParseCodListCommands(out)
 
@@ -155,4 +155,41 @@ func TestLearnListIdSelector(t *testing.T) {
 		},
 		commands,
 	)
+}
+
+func TestLearnListRichDefault(t *testing.T) {
+	wb := SetupWorkbench(t)
+	defer wb.Close()
+
+	shellPid := wb.LaunchFakeShell()
+	wb.RunCodCmd("init", strconv.Itoa(shellPid), "bash")
+	wb.RunCodCmd("learn", "--", "binaries/cat.py", "--help")
+
+	out := wb.RunCodCmd("list")
+
+	require.Contains(t, out, "ID")
+	require.Contains(t, out, "Command")
+	require.Contains(t, out, "Description")
+	require.Contains(t, out, "Completions")
+	require.Contains(t, out, "binaries/cat.py --help")
+	require.Contains(t, out, "Concatenate FILE(s) to standard output.")
+	require.Contains(t, out, "19")
+}
+
+func TestShowCommandDetails(t *testing.T) {
+	wb := SetupWorkbench(t)
+	defer wb.Close()
+
+	shellPid := wb.LaunchFakeShell()
+	wb.RunCodCmd("init", strconv.Itoa(shellPid), "bash")
+	wb.RunCodCmd("learn", "--", "binaries/cat.py", "--help")
+
+	out := wb.RunCodCmd("show", "cat.py")
+
+	require.Contains(t, out, "ID: 1")
+	require.Contains(t, out, "binaries/cat.py --help")
+	require.Contains(t, out, "Description: Concatenate FILE(s) to standard output.")
+	require.Contains(t, out, "Completions: 19")
+	require.Contains(t, out, "--number")
+	require.Contains(t, out, "number all output lines")
 }

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -42,7 +42,7 @@ func TestUpdateReplace(t *testing.T) {
 	wb.CopyFile("binaries/foo_v2.py", tmpCat)
 	wb.RunCodCmd("update", "**")
 
-	out = wb.RunCodCmd("list")
+	out = wb.RunCodCmd("list", "--format", "plain")
 	parsed := wb.ParseCodListCommands(out)
 	require.Equal(t,
 		[]string{
@@ -68,14 +68,14 @@ func TestUpdateMerge(t *testing.T) {
 	wb.CopyFile("binaries/foo_v1.py", tmpCat)
 	wb.RunCodCmd("learn", "--", tmpCat, "--help")
 
-	out := wb.RunCodCmd("list")
+	out := wb.RunCodCmd("list", "--format", "plain")
 	parsed := wb.ParseCodListCommands(out)
 	require.Equal(t, len(parsed), 1)
 
 	wb.CopyFile("binaries/foo_v2.py", tmpCat)
 	wb.RunCodCmd("learn", "--", tmpCat, "gg", "--help")
 
-	out = wb.RunCodCmd("list")
+	out = wb.RunCodCmd("list", "--format", "plain")
 	parsed = wb.ParseCodListCommands(out)
 	require.Equal(
 		t,
@@ -86,7 +86,7 @@ func TestUpdateMerge(t *testing.T) {
 
 	wb.RunCodCmd("update", "**")
 
-	out = wb.RunCodCmd("list")
+	out = wb.RunCodCmd("list", "--format", "plain")
 	parsed = wb.ParseCodListCommands(out)
 	require.Equal(t, 1, len(parsed))
 }
@@ -100,13 +100,13 @@ func TestUpdateNoChange(t *testing.T) {
 	wb.RunCodCmd("init", shellPid, "bash")
 
 	wb.RunCodCmd("learn", "--", "binaries/cat.py", "--help")
-	out := wb.RunCodCmd("list")
+	out := wb.RunCodCmd("list", "--format", "plain")
 	parsed := wb.ParseCodListMap(out)
 	require.Equal(t, len(parsed), 1)
 
 	wb.RunCodCmd("update", "**")
 
-	out = wb.RunCodCmd("list")
+	out = wb.RunCodCmd("list", "--format", "plain")
 	parsed = wb.ParseCodListMap(out)
 	require.Equal(t, len(parsed), 1)
 }
@@ -122,7 +122,7 @@ func TestUpdateBroken(t *testing.T) {
 	tmpCat := wb.InTmpDataPath("cat1")
 	wb.CopyFile("binaries/cat.py", tmpCat)
 	wb.RunCodCmd("learn", "--", tmpCat, "--help")
-	out := wb.RunCodCmd("list")
+	out := wb.RunCodCmd("list", "--format", "plain")
 	parsed := wb.ParseCodListMap(out)
 	require.Equal(t, len(parsed), 1)
 
@@ -131,7 +131,7 @@ func TestUpdateBroken(t *testing.T) {
 
 	wb.RunCodCmd("update", "**")
 
-	out = wb.RunCodCmd("list")
+	out = wb.RunCodCmd("list", "--format", "plain")
 	parsed = wb.ParseCodListMap(out)
 	require.Equal(t, make(map[int]string), parsed)
 }

--- a/ui.go
+++ b/ui.go
@@ -90,6 +90,9 @@ var styleTable = map[string]string{
 }
 
 func (ui TerminalUI) Styled(style, text string) (res string) {
+	if os.Getenv("NO_COLOR") != "" || !terminal.IsTerminal(1) {
+		return text
+	}
 	control, ok := styleTable[style]
 	if !ok {
 		panic(fmt.Errorf("unknown style: %v", style))


### PR DESCRIPTION
  - `Description` in `datastore.HelpPage`.
  - `Description` in `datastore.Completion`.
  - added: SQLite schema v2 with `Description`-col och v1 -> v2-migration.
  - added: prefix-query for completions with `GetCompletionsByPrefix`.
  - Update: parser default- and argparse-help can extract cmd desc & item desc.
  - Updated parser-tests, verifies desc and deduplications.
  - Added: datastore-tests for schema v2, migrations, desc and prefix-query.
  - Added: `cod list` as rich table (default setting).
  - Added: `cod list --format plain` legacy mode for tab-output.
  - Added: `cod show <selector...>` with details for cmd's and completions.
```bash
 ->  cod show cod                                                                                               
ID: 5
Command: /Users/stefan/go/bin/cod --help
Executable:
Description: -
Completions: 0
```
  - Updated: E2E-tests for plain-format and added some new rich list/show-tests.
  - Refactored: some small stuff.

**Things to pickup**
  - saknar tydlig inventarie av completions och descriptions, 0 0 just nu
  - lägg till descriptions på fler aspekter med tab-completions
  - skulle vara nice om config filen läste in ens env fil och gjorde configen baserat på os
  - bättre TUI